### PR TITLE
add a basic README that points to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# feather-design-system
+# Feather Design System
+
+Feather is a Vue-based design system for creating consistent 
+web UIs that follow best practices for typography, contrast,
+and layout.
+
+# Documentation
+
+Documentation is currently available here: https://prsv.z13.web.core.windows.net/


### PR DESCRIPTION
I assume eventually the docs will be at a "real" URL, but this at least gives a pointer to the docs for now since the repo is still very sparse on info.