### PR TITLE
Fixing focus trap

### DIFF
--- a/packages/@featherds/dialog/src/components/FocusTrap.spec.js
+++ b/packages/@featherds/dialog/src/components/FocusTrap.spec.js
@@ -86,26 +86,74 @@ describe("FocusTrap.vue", () => {
       });
     });
     describe("trapFocus", () => {
-      it("should set lastFocus to event.target if it's inside content element", () => {
+      it("should set lastFocus to event.target if it's inside content element", (done) => {
         wrapper = getWrapper({ props, slots, attachTo: document.body });
         const vm = wrapper.vm;
         const first = wrapper.find("#first").element;
         vm.trapFocus({ target: first });
-        expect(vm.lastFocus).toBe(first);
+        setTimeout(() => {
+          expect(vm.lastFocus).toBe(first);
+          done();
+        }, 1);
       });
-      it("should loop focus back to last element", () => {
+      it("should loop focus back to last element if focusing before", (done) => {
         wrapper = getWrapper({ props, slots });
         const vm = wrapper.vm;
+
+        //add an element before
+        var button = document.createElement("BUTTON");
+        button.id = "pre-button";
+        var t = document.createTextNode("Test Button");
+        button.appendChild(t);
+        document.body.appendChild(button);
+
         document.body.appendChild(wrapper.element);
         //focus first element
         const first = wrapper.find("#first").element;
         vm.lastFocus = first;
+        const butt = document.getElementById("pre-button");
         const last = wrapper.find("#last").element;
-        //try to focus something outside of element
-        vm.trapFocus({ target: document.body });
+
+        //try to focus something before the trap
+        vm.trapFocus({ target: butt });
+
         //should set focus to last
-        expect(vm.lastFocus).toBe(last);
-        document.body.removeChild(wrapper.element);
+        setTimeout(() => {
+          expect(vm.lastFocus).toBe(last);
+          document.body.removeChild(wrapper.element);
+          document.body.removeChild(butt);
+          done();
+        }, 1);
+      });
+      it("should loop focus back to first element if focusing after", (done) => {
+        wrapper = getWrapper({ props, slots });
+        const vm = wrapper.vm;
+
+        document.body.appendChild(wrapper.element);
+
+        //add an element after
+        var button = document.createElement("BUTTON");
+        button.id = "post-button";
+        var t = document.createTextNode("Test Button");
+        button.appendChild(t);
+        document.body.appendChild(button);
+
+        //focus last element
+        const first = wrapper.find("#first").element;
+        const butt = document.getElementById("post-button");
+        const last = wrapper.find("#last").element;
+        vm.lastFocus = last;
+
+        //try to focus something after the trap
+        vm.trapFocus({ target: butt });
+
+        //should set focus to first
+        setTimeout(() => {
+          expect(vm.lastFocus).toBe(first);
+          document.body.removeChild(wrapper.element);
+          document.body.removeChild(butt);
+          done();
+        }, 1);
       });
     });
     describe("focusFirstDescendant", () => {


### PR DESCRIPTION
Issues were usually seen in FF - order when tabbing and reverse tabbing had issues where some items never got selected.