### PR TITLE
Adding full validation support and examples to form elements

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -46,4 +46,3 @@ jobs:
       - name: Azure logout
         run: |
           az logout
-

--- a/demo/router.js
+++ b/demo/router.js
@@ -1,8 +1,8 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 import routes from "./routes";
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory("/demos/"),
   routes,
 });
 

--- a/docs/.vuepress/examples/Forms/ValidationExamples.vue
+++ b/docs/.vuepress/examples/Forms/ValidationExamples.vue
@@ -1,0 +1,34 @@
+<src>
+  ./YupSimple.vue
+  ./YupAll.vue
+</src>
+<template>
+  <FeatherDemo :demos="demos" />
+</template>
+<script>
+import YupSimple from "./YupSimple.vue";
+import YupAll from "./YupAll.vue";
+import { ref, getCurrentInstance, markRaw } from "vue";
+export default {
+  setup() {
+    const showSource = ref(false);
+    const instance = getCurrentInstance();
+    const demos = ref([
+      {
+        _text: "Validation Setup",
+        component: markRaw(YupSimple),
+        source: instance.type.srcs["YupSimple"],
+      },
+      {
+        _text: "All Elements",
+        component: markRaw(YupAll),
+        source: instance.type.srcs["YupAll"],
+      },
+    ]);
+
+    return {
+      demos,
+    };
+  },
+};
+</script>

--- a/docs/.vuepress/examples/Forms/YupAll.vue
+++ b/docs/.vuepress/examples/Forms/YupAll.vue
@@ -1,7 +1,7 @@
 <template>
   <form @submit="onSubmit" novalidate>
     * indicates required
-    <ValidationHeader ref="validateheader" />
+    <ValidationHeader :errorList="errorMessages" />
     <FeatherInput
       label="Email *"
       :modelValue="email"
@@ -120,7 +120,7 @@ import allCountries from "./countries.js";
 
 export default {
   setup() {
-    useForm();
+    const form = useForm();
     //Field values and validation rules
     const name = ref("");
     const nameV = string().required("Required");
@@ -272,16 +272,14 @@ export default {
     const commentV = string().required("Required");
 
     //General Error variables
-    const form = inject("featherForm", false);
+    const errorMessages = ref([]);
     const submitting = ref();
-    const validateheader = ref();
     const alert = ref();
     const onSubmit = (e) => {
       e.preventDefault();
-      let errors = 0;
-      errors = validateheader.value.runValidation();
+      errorMessages.value = form.validate();
 
-      if (!errors) {
+      if (!errorMessages.value.length) {
         submitting.value = true;
         alert.value.textContent = "Submitting form, please wait";
 
@@ -292,7 +290,6 @@ export default {
       }
     };
 
-    const addHash = (str) => `#${str}`;
     return {
       email,
       emailV,
@@ -321,10 +318,10 @@ export default {
       comment,
       commentV,
       onSubmit,
-      addHash,
       submitting,
       alert,
-      validateheader
+      form,
+      errorMessages
     };
   },
   components: {

--- a/docs/.vuepress/examples/Forms/YupAll.vue
+++ b/docs/.vuepress/examples/Forms/YupAll.vue
@@ -1,0 +1,304 @@
+<template>
+  <form @submit="onSubmit" novalidate>
+    * indicates required
+    <div class="errors" v-if="errors.length">
+      <div class="error-heading" tabindex="-1" ref="heading">
+        {{ errorsHeading }}
+      </div>
+      <ul>
+        <li v-for="item in errors" :key="item.inputId">
+          <a href="#" @click.prevent="focusElement(item.inputId)">{{
+            item.fullMessage
+          }}</a>
+        </li>
+      </ul>
+    </div>
+    <FeatherInput
+      label="Email *"
+      :modelValue="email"
+      :schema="emailV"
+      required
+    />
+
+    <FeatherInput
+      label="Name *"
+      :modelValue="name"
+      :schema="nameV"
+      required
+    />
+
+    <FeatherProtectedInput
+      label="Password *"
+      v-model="pass"
+      :schema="passV"
+      required
+    ></FeatherProtectedInput>
+
+    <FeatherProtectedInput
+      label="Confirm Password *"
+      v-model="pass2"
+      :schema="pass2V"
+      required
+    ></FeatherProtectedInput>
+
+    <FeatherDateInput
+      v-model="dob"
+      :schema="dobV"
+      label="Date of Birth *"
+      :disabledDates="dobDisabled"
+      required
+    ></FeatherDateInput>
+
+    <FeatherSelect
+      label="Country *"
+      :options="countries"
+      v-model="country"
+      :schema="countryV"
+      required
+    >
+    </FeatherSelect>
+
+    <FeatherRadioGroup :label="'What is your sex? *'" v-model="sexSelected" :schema="sexV">
+      <FeatherRadio
+        v-for="item in sexes"
+        :value="item.value"
+        :key="item.name"
+        >{{ item.name }}</FeatherRadio
+      >
+    </FeatherRadioGroup>
+
+    <FeatherAutocomplete
+      label="Favourite films *"
+      type="multi"
+      v-model="films"
+      :schema="filmsV"
+      :selectionLimit="3"
+      :loading="filmsLoading"
+      :results="filmsResults"
+      @search="filmsSearch"
+      required
+    ></FeatherAutocomplete>
+
+    <FeatherCheckboxGroup
+      label="Please select your favourite pizza toppings *"
+      hint="Pineapple is not allowed."
+    >
+      <FeatherCheckbox v-model="pepperoni"> Pepperoni </FeatherCheckbox>
+      <FeatherCheckbox v-model="chicken"> Chicken </FeatherCheckbox>
+      <FeatherCheckbox v-model="olives"> Olives </FeatherCheckbox>
+      <FeatherCheckbox v-model="pineapple"> Pineapple </FeatherCheckbox>
+    </FeatherCheckboxGroup>
+
+    <FeatherTextarea
+      v-model="comment"
+      label="Leave a comment *"
+      :schema="commentV"
+      rows="5"
+      required
+    ></FeatherTextarea>
+
+    <button type="submit">Submit</button>
+    <div class="submitting" v-if="submitting">
+      <FeatherSpinner />
+    </div>
+    <div
+      class="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      ref="alert"
+    ></div>
+  </form>
+</template>
+<script>
+import { string, array, date } from "yup";
+import { ref, computed, provide, nextTick } from "vue";
+import { FeatherAutocomplete } from "@featherds/autocomplete";
+import { FeatherCheckbox, FeatherCheckboxGroup } from "@featherds/checkbox";
+import { FeatherDateInput } from "@featherds/date-input";
+import { FeatherDropdown } from "@featherds/dropdown";
+import { FeatherInput } from "@featherds/input";
+import { FeatherProtectedInput } from "@featherds/protected-input";
+import { FeatherRadio, FeatherRadioGroup } from "@featherds/radio";
+import { FeatherSelect } from "@featherds/select";
+import { FeatherTextarea } from "@featherds/textarea";
+
+import { FeatherSpinner } from "@featherds/progress";
+
+import allCountries from "./countries.js";
+
+export default {
+  setup() {
+    const controls = {};
+    provide("featherForm", {
+      register: (input, validate) => {
+        controls[input] = validate;
+      },
+    });
+    //Field values and validation rules
+    const name = ref("");
+    const nameV = string().required("Required");
+
+    const email = ref("");
+    const emailV = string().required("Required").email();
+
+    const pass = ref("");
+    const passV = string().required("Required");
+    const pass2 = ref("");
+    const pass2V = string().required("Required");
+
+    const dob = ref();
+    const dobV = date().required("Required").max(new Date(Date.now() - 86400000));
+    const dobDisabled = { from: new Date() };
+
+    const countries = allCountries;
+    const country = ref();
+    const countryV = string().required("Required");
+
+    const sexes = [
+        {
+          name: "Male",
+          value: "m",
+        },
+        {
+          name: "Female",
+          value: "f",
+        },
+        {
+          name: "Other",
+          value: "?",
+        },
+      ];
+    const sexSelected = ref();
+    const sexCustom = ref("");
+    const sexV = string().required("Required");
+
+    const films = ref([]);
+    const filmsV = array().required("Required").length(3);
+    let filmsTimeout = -1;
+    const filmsLoading = ref(false);
+    const allFilms = ["Terminator 2", "True Lies", "Eraser", "Last Action Hero", "Commando", "Predator", "Total Recall", "Twins", "Kung Fury 2"];
+    const filmsResults = ref([]);
+    const filmsSearch = function(q) {
+      filmsLoading.value = true;
+      clearTimeout(filmsTimeout);
+      filmsTimeout = setTimeout(() => {
+        filmsResults.value = allFilms
+          .filter((x) => x.toLowerCase().indexOf(q) > -1)
+          .map((x) => ({
+            _text: x,
+          }));
+        filmsLoading.value = false;
+      }, 500);
+    };
+
+    const pepperoni = ref(false);
+    const chicken = ref(false);
+    const olives = ref(false);
+    const pineapple = ref(false);
+
+    const comment = ref("");
+    const commentV = string().required("Required");
+
+    //General Error variables
+    const errors = ref([]);
+    const errorsHeading = ref("");
+    const heading = ref();
+    const submitting = ref();
+    const alert = ref();
+    const removeAsteriks = (str) => {
+      return str.replace(/ \*$/, "");
+    };
+    const focusElement = (id) => {
+      document.getElementById(id).focus();
+    };
+    const onSubmit = (e) => {
+      errors.value = [];
+      e.preventDefault();
+      const validation = Object.keys(controls).map((key) => {
+        return controls[key]();
+      });
+      errors.value = validation
+        .filter((x) => x.success === false)
+        .map((v) => {
+          v.fullMessage = `${removeAsteriks(v.label)} - ${v.message}`;
+          return v;
+        });
+
+      if (errors.value.length) {
+        errorsHeading.value = errors.value
+          ? errors.value.length + " errors"
+          : "";
+        nextTick(() => heading.value.focus());
+      } else {
+        submitting.value = true;
+        alert.value.textContent = "Submitting form, please wait";
+
+        setTimeout(() => {
+          alert.value.textContent = "Submission successful";
+          submitting.value = false;
+        }, 3000);
+      }
+    };
+
+    const addHash = (str) => `#${str}`;
+    return {
+      email,
+      emailV,
+      name,
+      nameV,
+      pass,
+      passV,
+      pass2,
+      pass2V,
+      dob,
+      dobV,
+      countries,
+      country,
+      countryV,
+      sexes,
+      sexSelected,
+      sexV,
+      dobDisabled,
+      films,
+      filmsV,
+      filmsLoading,
+      filmsResults,
+      filmsSearch,
+      pepperoni,
+      chicken,
+      olives,
+      pineapple,
+      comment,
+      commentV,
+      onSubmit,
+      errors,
+      errorsHeading,
+      heading,
+      addHash,
+      focusElement,
+      submitting,
+      alert,
+    };
+  },
+  components: {
+    FeatherAutocomplete,
+    FeatherCheckbox,
+    FeatherCheckboxGroup,
+    FeatherDateInput,
+    FeatherDropdown,
+    FeatherInput,
+    FeatherProtectedInput,
+    FeatherRadio,
+    FeatherRadioGroup,
+    FeatherSelect,
+    FeatherSpinner,
+    FeatherTextarea
+  },
+};
+</script>
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/typography";
+.alert {
+  @include screen-reader();
+}
+</style>

--- a/docs/.vuepress/examples/Forms/YupAll.vue
+++ b/docs/.vuepress/examples/Forms/YupAll.vue
@@ -281,7 +281,7 @@ export default {
       let errors = 0;
       errors = validateheader.value.runValidation();
 
-      if (!errors.length) {
+      if (!errors) {
         submitting.value = true;
         alert.value.textContent = "Submitting form, please wait";
 

--- a/docs/.vuepress/examples/Forms/YupSimple.vue
+++ b/docs/.vuepress/examples/Forms/YupSimple.vue
@@ -1,0 +1,86 @@
+<template>
+  <form @submit="onSubmit" novalidate>
+    * indicates required
+    <!--optional but recommended, use the Validation Header to format error messages-->
+    <ValidationHeader :errorList="errorMessages" />
+    <!--Pass a schema object and any inputs you have plus any other neccessary attributes-->
+    <FeatherInput
+      label="Email *"
+      :modelValue="email"
+      :schema="emailV"
+      required
+    />
+    <!--Provide feedback for form submission for sighted and screen reader users-->
+    <button type="submit">Submit</button>
+    <div class="submitting" v-if="submitting">
+      <FeatherSpinner />
+    </div>
+    <div
+      class="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      ref="alert"
+    ></div>
+  </form>
+</template>
+<script>
+import { string } from "yup";
+import { ref } from "vue";
+import { FeatherInput, ValidationHeader } from "@featherds/input";
+import { useForm } from "@featherds/input/src/components/useForm";
+
+import { FeatherSpinner } from "@featherds/progress";
+
+export default {
+  setup() {
+    //use the form object to controls can register for validation
+    const form = useForm();
+
+    //Field values and validation rules
+    const email = ref("");
+    const emailV = string().required("Required").email();
+
+    //General Error variables
+    const errorMessages = ref([]);
+    const submitting = ref();
+    const alert = ref();
+    const onSubmit = (e) => {
+      e.preventDefault();
+      //run validation and pass the messages to the Validation Header component
+      errorMessages.value = form.validate();
+
+      //Form submission boilerplate and user feedback
+      if (!errorMessages.value.length) {
+        submitting.value = true;
+        alert.value.textContent = "Submitting form, please wait";
+
+        setTimeout(() => {
+          alert.value.textContent = "Submission successful";
+          submitting.value = false;
+        }, 3000);
+      }
+    };
+
+    return {
+      email,
+      emailV,
+      onSubmit,
+      submitting,
+      alert,
+      form,
+      errorMessages
+    };
+  },
+  components: {
+    FeatherInput,
+    FeatherSpinner,
+    ValidationHeader
+  },
+};
+</script>
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/typography";
+.alert {
+  @include screen-reader();
+}
+</style>

--- a/docs/.vuepress/examples/Forms/countries.js
+++ b/docs/.vuepress/examples/Forms/countries.js
@@ -1,0 +1,6 @@
+export default [
+  { _text: "Antarctica" },
+  { _text: "Canada" },
+  { _text: "Narnia" },
+  { _text: "United States of America" },
+  { _text: "United Kingdom" },]

--- a/docs/.vuepress/menus/components.js
+++ b/docs/.vuepress/menus/components.js
@@ -12,6 +12,10 @@ module.exports = [
         name: "Variables",
         url: "/Components/Variables/",
       },
+      {
+        name: "Form Validation",
+        url: "/Components/FormValidation/",
+      },
     ],
   },
   {

--- a/docs/Components/Autocomplete/README.md
+++ b/docs/Components/Autocomplete/README.md
@@ -118,6 +118,7 @@ In the example above, we update the value array at the index where the icon need
 | labels         | object containing labels to be used by this component. Mainly used for i18n or customization of labels. See [Labels](#labels) example | `Object`            | `false`  | See [Labels](#labels) example           |
 | gridConfig     | array containing configuration for rendering the grid results. See [Grid Config](#grid-config) example                                | `Object`            | `false`  | See [Grid Config](#grid-config) example |
 | hideLabel      | hides the label for the input in scenarios like tables where it would get in the way                                                  | `Boolean`           | `false`  | -                                       |
+| schema         | a schema for use in validation                                                                                                        | `Object`            | `false`  | -                                       |
 
 ### Labels
 

--- a/docs/Components/Checkbox/README.md
+++ b/docs/Components/Checkbox/README.md
@@ -69,12 +69,14 @@ Instead use:
 
 ### Props
 
-| Name     | Description                                           | Type      | Required | Default |
-| -------- | ----------------------------------------------------- | --------- | -------- | ------- |
-| label    | label for the Checkbox group                          | `String`  | `true`   | -       |
-| hint     | hint text to be displayed below the group             | `String`  | `false`  | -       |
-| error    | error text to be displayed below the group            | `String`  | `false`  | -       |
-| vertical | when true will put Radio buttons in a vertical layout | `Boolean` | `false`  | `false` |
+| Name       | Description                                            | Type      | Required | Default |
+| ---------- | ------------------------------------------------------ | --------- | -------- | ------- |
+| modelValue | optional object of checkbox values for validation only | `Object`  | `false`  | -       |
+| label      | label for the Checkbox group                           | `String`  | `true`   | -       |
+| hint       | hint text to be displayed below the group              | `String`  | `false`  | -       |
+| error      | error text to be displayed below the group             | `String`  | `false`  | -       |
+| vertical   | when true will put Radio buttons in a vertical layout  | `Boolean` | `false`  | `false` |
+| schema     | a schema for use in validation                         | `Object`  | `false`  | -       |
 
 ### Slots
 
@@ -87,3 +89,7 @@ Instead use:
 ### Attributes
 
 Specifying a `class` or `data-ref-id` attribute will cause them to be applied to the component root container `div`. All other attributes are passed to the `input` where it makes sense. Some will be ignored if they conflict with attributes we need to use for accessibility.
+
+### Notes
+
+The structure of Checkboxes means that their value is atomic and not shared with the CheckboxGroup by default. For convenient validation, you can instead bind Checkbox values to properties of an `Object` and pass in a validation schema. However, this is totally optional and can also be achieved without using an `Object`. Please see the [Form Validation](/Components/FormValidation/) page for a working example.

--- a/docs/Components/DateInput/README.md
+++ b/docs/Components/DateInput/README.md
@@ -35,6 +35,7 @@ These components are often found in the form of workflows where data entry is th
 | mondayFirst   | should monday be first day of the week.                                                                                               | `Boolean` | `false`  | -                                     |
 | disabledDates | can be used to configure disabled dates. See [Disabled Dates](#disabled-dates)                                                        | `Object`  | `false`  | See [Disabled Dates](#disabled-dates) |
 | labels        | Object containing labels to be used by this component. Mainly used for i18n or customization of labels. See [Labels](#labels) example | `Object`  | `false`  | See [Labels](#labels) example         |
+| schema        | a schema for use in validation                                                                                                        | `Object`  | `false`  | -                                     |
 
 ### Labels
 

--- a/docs/Components/FormValidation/README.md
+++ b/docs/Components/FormValidation/README.md
@@ -18,7 +18,7 @@ We really like **Yup** for it's expressive and flexible schemas and so we use it
 
 ## Examples
 
-<Forms-YupAll />
+<Forms-ValidationExamples />
 
 ## Patterns
 
@@ -40,3 +40,42 @@ Feather DS elements that you can use in valdiation contexts include;
 - `Radio`
 - `Select`
 - `Textarea`
+
+
+## Setup
+See the `Validation Setup` example above for a working implementation of the below.
+
+### Components
+Simply add `schema` props to any inputs you need to validate and configure the rules in your code. We provide a basic `ValidationHeader` component from the [Input](/Components/Input/) package for convenience, should you require it.
+
+```html
+  <ValidationHeader :errorList="errorMessages" />
+  <FeatherInput
+    label="Email *"
+    :modelValue="email"
+    :schema="emailV"
+    required
+  />
+```
+
+### useForm
+The crux of the validation is the `useForm` composable. This uses the Vue Provide/Inject pattern to enable validation in any form controls. As long as you instance the `useForm` in your parent component setup method where your form is declared, all components will automatically register if they have a schema supplied to them.
+
+That means all you have to do is simply call the `validate` function when appropriate to validate the entire form. You can pass the output of the function to the `ValidationHeader` component and it will display the errors in a list for extra usability.
+
+```js
+import { useForm } from "@featherds/input/src/components/useForm";
+
+export default {
+  setup() {
+    const form = useForm();
+    //...
+    const onSubmit = (e) => {
+      e.preventDefault();
+      //run validation and assign the error messages to a variable
+      errorMessages.value = form.validate();
+      //...
+    }
+  }
+}
+```

--- a/docs/Components/FormValidation/README.md
+++ b/docs/Components/FormValidation/README.md
@@ -1,0 +1,42 @@
+---
+title: "Form Validation"
+pre: "@featherds/input"
+description: "Guidance and support for effective forms."
+lang: en-US
+tags: ["validation", "component"]
+menu: components
+---
+
+Web applications are often fundamentally a means to consume or present information. When designing forms, aside from having well-designed controls and sensible layouts, forms should always be clear about their validation.
+Feather DS controls are designed to work well with common validation paradigms, but we typically like to use;
+* Vee-Validate
+* Yup
+
+::: tip Recommendation
+We really like **Yup** for it's expressive and flexible schemas and so we use it in the examples below
+:::
+
+## Examples
+
+<Forms-YupAll />
+
+## Patterns
+
+We encourage you to use best practices for validation like in the example above;
+* Use inline validation
+* Validate on blur
+* Communicate your errors clearly
+* Indicate which fields are required
+* Summarise errors and link to the field
+
+## Elements
+
+Feather DS elements that you can use in valdiation contexts include;
+- `Autocomplete`
+- `Checkbox`
+- `DateInput`
+- `Input`
+- `ProtectedInput`
+- `Radio`
+- `Select`
+- `Textarea`

--- a/docs/Components/Input/README.md
+++ b/docs/Components/Input/README.md
@@ -49,6 +49,8 @@ Inputs can be used as a singular object in a layout, or they can be paired toget
 | disabled   | puts the Input into a disabled state                                                             | `Boolean` | `false`  | `false`      |
 | maxlength  | maximum amount of characters this Input will accept                                              | `Number`  | `false`  | 0 - no limit |
 | hideLabel  | hides the label for the Input in scenarios like tables where it would get in the way             | `Boolean` | `false`  | -            |
+| id         | an ID that can be will be assigned to the input element                                          | `String`  | `false`  | -            |
+| schema     | a schema for use in validation                                                                   | `Object`  | `false`  | -            |
 
 ### Events
 

--- a/docs/Components/Input/README.md
+++ b/docs/Components/Input/README.md
@@ -72,3 +72,19 @@ Inputs can be used as a singular object in a layout, or they can be paired toget
 ### Attributes
 
 Specifying an `class` or `data-ref-id` attribute will cause them to be applied to the component root container `div`. All other attributes are inherited to the `input` where applicable. Some will be ignored if they conflict with attributes used for accessibility.
+
+
+## ValidationHeader
+This is an element designed to be used in conjunction with forms using the `yup` validation library. This component displays a list of errors and links to the errored fields which helps in best practices for form validation. Please see the examples in the [Form Validation page](/Components/FormValidation/#examples)
+
+### Props
+
+| Name       | Description                                                      | Type    | Required | Default |
+| ---------- | ---------------------------------------------------------------- | ------- | -------- | ------- |
+| errorList  | an array of yup `ValidationError` objects produced by validation | `Array` | `false`  | `[]`    |
+
+
+### data-ref-ids
+
+- `feather-validation-header` - the root element
+

--- a/docs/Components/Radio/README.md
+++ b/docs/Components/Radio/README.md
@@ -57,6 +57,7 @@ Radio buttons should be used in a [RadioGroup](#RadioGroup). The Radio Group wil
 | hint       | hint text to be displayed below the group             | `String`  | `false`  | -       |
 | error      | error text to be displayed below the group            | `String`  | `false`  | -       |
 | vertical   | when true will put radio buttons in a vertical layout | `Boolean` | `false`  | `false` |
+| schema     | a schema for use in validation                        | `Object`  | `false`  | -       |
 
 ### Events
 

--- a/docs/Components/Select/README.md
+++ b/docs/Components/Select/README.md
@@ -81,6 +81,7 @@ The following example allows `10` items to be displayed before scrolling.
 | hint       | hint string to display under select                                                     | `String`        | `false`  | -           |
 | background | sets label background color to `background`                                             | `Boolean`       | `false`  | `false`     |
 | hideLabel  | hides the label for the input in scenarios like tables where it would get in the way    | `Boolean`       | `false`  | -           |
+| schema     | a schema for use in validation                                                          | `Object`        | `false`  | -           |
 
 ### Events
 

--- a/docs/Components/Textarea/README.md
+++ b/docs/Components/Textarea/README.md
@@ -35,6 +35,7 @@ Text areas should be used on forms, dialogs, background, and foreground surfaces
 | maxlength  | maximum amount of characters this textarea will accept                                           | `Number`  | `false`  | 0 - no limit |
 | auto       | when true the textarea will automatically grow                                                   | `Boolean` | `false`  | `false`      |
 | hideLabel  | hides the label for the input in scenarios like tables where it would get in the way             | `Boolean` | `false`  | -            |
+| schema     | a schema for use in validation                                                                   | `Object`  | `false`  | -            |
 
 ### Events
 

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.js
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.js
@@ -344,7 +344,7 @@ const baseFunctionality = (type) => {
   });
 };
 
-describe("Feather Autocomplete", () => {
+describe("FeatherAutocomplete", () => {
   describe("base functionality", () => {
     baseFunctionality(TYPES.multi);
     baseFunctionality(TYPES.single);

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -654,7 +654,7 @@ export default {
       this.$refs.input.focus();
     },
     handleInputBlur() {
-      validate();
+      this.validate();
       this.strategy.handleInputBlur();
       if (this.forceCloseResults || !this.showMenu) {
         this.handleOutsideClick();

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -158,11 +158,11 @@ import { getSafeId } from "@featherds/utils/id";
 import { KEYCODES } from "@featherds/utils/keys";
 import { toView } from "@featherds/utils/scroll";
 import { useLabelProperty } from "@featherds/composables/LabelProperty";
-import { toRef } from "vue";
 import { useResultList } from "./Results/ResultList";
 import { useResultGrid } from "./Results/ResultGrid";
+import { useValidation } from "@featherds/input/src/components/useValidation";
 import HighlightMixin from "./Highlight/HighlightMixin";
-import { markRaw } from "vue";
+import { ref, computed, toRef, markRaw } from "vue";
 
 const LABELS = {
   noResults: "No results found",
@@ -236,6 +236,10 @@ export default {
     },
     gridConfig: {
       type: Array,
+    },
+    schema: {
+      type: Object,
+      required: false,
     },
   },
   data() {
@@ -334,9 +338,6 @@ export default {
     },
     subTextId() {
       return getSafeId("feather-autocomplete-description");
-    },
-    inputId() {
-      return getSafeId("feather-autocomplete-input");
     },
     resultsId() {
       return getSafeId("feather-autocomplete-input-results");
@@ -653,6 +654,7 @@ export default {
       this.$refs.input.focus();
     },
     handleInputBlur() {
+      validate();
       this.strategy.handleInputBlur();
       if (this.forceCloseResults || !this.showMenu) {
         this.handleOutsideClick();
@@ -726,12 +728,31 @@ export default {
     } else {
       resultsRender = useResultList();
     }
+
+    const incomingId = toRef(props, "id");
+    const inputId = computed(() => {
+      if (incomingId.value) {
+        return incomingId.value;
+      }
+      return getSafeId("feather-autocomplete-input");
+    });
+
+    const { validate } = useValidation(
+      inputId,
+      toRef(props, "modelValue"),
+      props.label,
+      props.schema
+    );
+
     return {
       ...labels,
       active: resultsRender.active,
       handleResultNavigation: resultsRender.handleKeyPress,
       resetResultIndex: resultsRender.reset,
       selectFirst: resultsRender.first,
+      inputId,
+      incomingId,
+      validate,
     };
   },
   mounted() {

--- a/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.js.snap
+++ b/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Feather Autocomplete base functionality multi disabled state should render in a disabled state with a value 1`] = `
+exports[`FeatherAutocomplete base functionality multi disabled state should render in a disabled state with a value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -15,17 +15,17 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised disabled"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -33,7 +33,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -41,11 +41,11 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -146,7 +146,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -171,7 +171,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -201,7 +201,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -213,13 +213,13 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi disabled state should render in a disabled state with no value 1`] = `
+exports[`FeatherAutocomplete base functionality multi disabled state should render in a disabled state with no value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -228,17 +228,17 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container disabled"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -246,7 +246,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 16px;"
       >
@@ -254,11 +254,11 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -315,7 +315,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -340,7 +340,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -370,7 +370,7 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -382,13 +382,13 @@ exports[`Feather Autocomplete base functionality multi disabled state should ren
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi should lower label when there is no value and autocomplete doesnt have focus 1`] = `
+exports[`FeatherAutocomplete base functionality multi should lower label when there is no value and autocomplete doesnt have focus 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -397,17 +397,17 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -415,7 +415,7 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 16px;"
       >
@@ -423,11 +423,11 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -482,7 +482,7 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -507,7 +507,7 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -537,7 +537,7 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -549,13 +549,13 @@ exports[`Feather Autocomplete base functionality multi should lower label when t
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi should not leave previous search results visible whilst new search is being performed 1`] = `
+exports[`FeatherAutocomplete base functionality multi should not leave previous search results visible whilst new search is being performed 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -565,7 +565,7 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -573,10 +573,10 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -584,7 +584,7 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -592,11 +592,11 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -651,7 +651,7 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -676,7 +676,7 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -784,7 +784,7 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -796,13 +796,13 @@ exports[`Feather Autocomplete base functionality multi should not leave previous
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi should raise the label when the autocomplete has a value 1`] = `
+exports[`FeatherAutocomplete base functionality multi should raise the label when the autocomplete has a value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -811,17 +811,17 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -829,7 +829,7 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -837,11 +837,11 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -982,7 +982,7 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -1007,7 +1007,7 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -1037,7 +1037,7 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1049,13 +1049,13 @@ exports[`Feather Autocomplete base functionality multi should raise the label wh
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi should show loading spinner when search is performed 1`] = `
+exports[`FeatherAutocomplete base functionality multi should show loading spinner when search is performed 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1065,7 +1065,7 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -1073,10 +1073,10 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1084,7 +1084,7 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -1092,11 +1092,11 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -1151,7 +1151,7 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -1176,7 +1176,7 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -1224,7 +1224,7 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1236,13 +1236,13 @@ exports[`Feather Autocomplete base functionality multi should show loading spinn
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality multi should show no results text when search returns no results 1`] = `
+exports[`FeatherAutocomplete base functionality multi should show no results text when search returns no results 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1252,7 +1252,7 @@ exports[`Feather Autocomplete base functionality multi should show no results te
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -1260,10 +1260,10 @@ exports[`Feather Autocomplete base functionality multi should show no results te
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1271,7 +1271,7 @@ exports[`Feather Autocomplete base functionality multi should show no results te
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -1279,11 +1279,11 @@ exports[`Feather Autocomplete base functionality multi should show no results te
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -1338,7 +1338,7 @@ exports[`Feather Autocomplete base functionality multi should show no results te
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -1363,7 +1363,7 @@ exports[`Feather Autocomplete base functionality multi should show no results te
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -1420,7 +1420,7 @@ exports[`Feather Autocomplete base functionality multi should show no results te
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1432,13 +1432,13 @@ exports[`Feather Autocomplete base functionality multi should show no results te
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single disabled state should render in a disabled state with a value 1`] = `
+exports[`FeatherAutocomplete base functionality single disabled state should render in a disabled state with a value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1447,17 +1447,17 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised disabled"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1465,7 +1465,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -1473,11 +1473,11 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -1534,12 +1534,12 @@ exports[`Feather Autocomplete base functionality single disabled state should re
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <a
             class="action-icon hide-when-disabled"
             data-ref-id="feather-form-element-clear"
-            data-v-051667c2=""
+            data-v-3828e91d=""
             data-v-d1dfbdf8=""
             href="#"
             title="Clear value"
@@ -1581,7 +1581,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -1611,7 +1611,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1623,13 +1623,13 @@ exports[`Feather Autocomplete base functionality single disabled state should re
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single disabled state should render in a disabled state with no value 1`] = `
+exports[`FeatherAutocomplete base functionality single disabled state should render in a disabled state with no value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1638,17 +1638,17 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container disabled"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1656,7 +1656,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 16px;"
       >
@@ -1664,11 +1664,11 @@ exports[`Feather Autocomplete base functionality single disabled state should re
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -1725,7 +1725,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -1750,7 +1750,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -1780,7 +1780,7 @@ exports[`Feather Autocomplete base functionality single disabled state should re
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1792,13 +1792,13 @@ exports[`Feather Autocomplete base functionality single disabled state should re
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single should lower label when there is no value and autocomplete doesnt have focus 1`] = `
+exports[`FeatherAutocomplete base functionality single should lower label when there is no value and autocomplete doesnt have focus 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1807,17 +1807,17 @@ exports[`Feather Autocomplete base functionality single should lower label when 
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1825,7 +1825,7 @@ exports[`Feather Autocomplete base functionality single should lower label when 
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 16px;"
       >
@@ -1833,11 +1833,11 @@ exports[`Feather Autocomplete base functionality single should lower label when 
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -1892,7 +1892,7 @@ exports[`Feather Autocomplete base functionality single should lower label when 
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -1917,7 +1917,7 @@ exports[`Feather Autocomplete base functionality single should lower label when 
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -1947,7 +1947,7 @@ exports[`Feather Autocomplete base functionality single should lower label when 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -1959,13 +1959,13 @@ exports[`Feather Autocomplete base functionality single should lower label when 
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single should not leave previous search results visible whilst new search is being performed 1`] = `
+exports[`FeatherAutocomplete base functionality single should not leave previous search results visible whilst new search is being performed 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -1975,7 +1975,7 @@ exports[`Feather Autocomplete base functionality single should not leave previou
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -1983,10 +1983,10 @@ exports[`Feather Autocomplete base functionality single should not leave previou
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -1994,7 +1994,7 @@ exports[`Feather Autocomplete base functionality single should not leave previou
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -2002,11 +2002,11 @@ exports[`Feather Autocomplete base functionality single should not leave previou
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -2061,7 +2061,7 @@ exports[`Feather Autocomplete base functionality single should not leave previou
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -2086,7 +2086,7 @@ exports[`Feather Autocomplete base functionality single should not leave previou
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -2193,7 +2193,7 @@ exports[`Feather Autocomplete base functionality single should not leave previou
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -2205,13 +2205,13 @@ exports[`Feather Autocomplete base functionality single should not leave previou
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single should raise the label when the autocomplete has a value 1`] = `
+exports[`FeatherAutocomplete base functionality single should raise the label when the autocomplete has a value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -2220,17 +2220,17 @@ exports[`Feather Autocomplete base functionality single should raise the label w
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -2238,7 +2238,7 @@ exports[`Feather Autocomplete base functionality single should raise the label w
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -2246,11 +2246,11 @@ exports[`Feather Autocomplete base functionality single should raise the label w
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -2305,12 +2305,12 @@ exports[`Feather Autocomplete base functionality single should raise the label w
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <a
             class="action-icon hide-when-disabled"
             data-ref-id="feather-form-element-clear"
-            data-v-051667c2=""
+            data-v-3828e91d=""
             data-v-d1dfbdf8=""
             href="#"
             title="Clear value"
@@ -2352,7 +2352,7 @@ exports[`Feather Autocomplete base functionality single should raise the label w
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -2382,7 +2382,7 @@ exports[`Feather Autocomplete base functionality single should raise the label w
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -2394,13 +2394,13 @@ exports[`Feather Autocomplete base functionality single should raise the label w
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single should show loading spinner when search is performed 1`] = `
+exports[`FeatherAutocomplete base functionality single should show loading spinner when search is performed 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -2410,7 +2410,7 @@ exports[`Feather Autocomplete base functionality single should show loading spin
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -2418,10 +2418,10 @@ exports[`Feather Autocomplete base functionality single should show loading spin
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -2429,7 +2429,7 @@ exports[`Feather Autocomplete base functionality single should show loading spin
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -2437,11 +2437,11 @@ exports[`Feather Autocomplete base functionality single should show loading spin
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -2496,7 +2496,7 @@ exports[`Feather Autocomplete base functionality single should show loading spin
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -2521,7 +2521,7 @@ exports[`Feather Autocomplete base functionality single should show loading spin
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -2569,7 +2569,7 @@ exports[`Feather Autocomplete base functionality single should show loading spin
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -2581,13 +2581,13 @@ exports[`Feather Autocomplete base functionality single should show loading spin
 </div>
 `;
 
-exports[`Feather Autocomplete base functionality single should show no results text when search returns no results 1`] = `
+exports[`FeatherAutocomplete base functionality single should show no results text when search returns no results 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -2597,7 +2597,7 @@ exports[`Feather Autocomplete base functionality single should show no results t
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -2605,10 +2605,10 @@ exports[`Feather Autocomplete base functionality single should show no results t
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -2616,7 +2616,7 @@ exports[`Feather Autocomplete base functionality single should show no results t
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -2624,11 +2624,11 @@ exports[`Feather Autocomplete base functionality single should show no results t
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -2683,7 +2683,7 @@ exports[`Feather Autocomplete base functionality single should show no results t
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -2708,7 +2708,7 @@ exports[`Feather Autocomplete base functionality single should show no results t
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -2765,7 +2765,7 @@ exports[`Feather Autocomplete base functionality single should show no results t
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -2777,13 +2777,13 @@ exports[`Feather Autocomplete base functionality single should show no results t
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should move chip selection left when left arrow is pressed, so long it is not the left most token 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should move chip selection left when left arrow is pressed, so long it is not the left most token 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -2793,7 +2793,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -2801,10 +2801,10 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -2812,7 +2812,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -2820,11 +2820,11 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -2966,7 +2966,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -2991,7 +2991,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -3021,7 +3021,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -3033,13 +3033,13 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should move chip selection right when right arrow is pressed, so long it is not the right most token 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should move chip selection right when right arrow is pressed, so long it is not the right most token 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -3049,7 +3049,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -3057,10 +3057,10 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -3068,7 +3068,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -3076,11 +3076,11 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -3222,7 +3222,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -3247,7 +3247,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -3277,7 +3277,7 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -3289,13 +3289,13 @@ exports[`Feather Autocomplete multi:specific chip selection should move chip sel
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should not move chip selection when left is pressed on the left most token 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should not move chip selection when left is pressed on the left most token 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -3305,7 +3305,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -3313,10 +3313,10 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -3324,7 +3324,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -3332,11 +3332,11 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -3478,7 +3478,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -3503,7 +3503,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -3533,7 +3533,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -3545,13 +3545,13 @@ exports[`Feather Autocomplete multi:specific chip selection should not move chip
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should not perform any chip navigation when there is text 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should not perform any chip navigation when there is text 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -3561,7 +3561,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -3569,10 +3569,10 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -3580,7 +3580,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -3588,11 +3588,11 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -3733,7 +3733,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -3758,7 +3758,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -3788,7 +3788,7 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -3800,13 +3800,13 @@ exports[`Feather Autocomplete multi:specific chip selection should not perform a
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should select rightmost token if left is pressed whilst navigating the menu and there is no search text 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should select rightmost token if left is pressed whilst navigating the menu and there is no search text 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -3816,7 +3816,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -3824,10 +3824,10 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -3835,7 +3835,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -3843,11 +3843,11 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -3989,7 +3989,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -4014,7 +4014,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -4103,7 +4103,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -4115,13 +4115,13 @@ exports[`Feather Autocomplete multi:specific chip selection should select rightm
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should select the right most chip when left arrow is pressed and input has no text 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should select the right most chip when left arrow is pressed and input has no text 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -4131,7 +4131,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -4139,10 +4139,10 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -4150,7 +4150,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -4158,11 +4158,11 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -4304,7 +4304,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -4329,7 +4329,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -4359,7 +4359,7 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -4371,13 +4371,13 @@ exports[`Feather Autocomplete multi:specific chip selection should select the ri
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific chip selection should should deselect chip when right arrow is pressed on right most token 1`] = `
+exports[`FeatherAutocomplete multi:specific chip selection should should deselect chip when right arrow is pressed on right most token 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -4387,7 +4387,7 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -4395,10 +4395,10 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -4406,7 +4406,7 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -4414,11 +4414,11 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -4559,7 +4559,7 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -4584,7 +4584,7 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -4614,7 +4614,7 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -4626,13 +4626,13 @@ exports[`Feather Autocomplete multi:specific chip selection should should desele
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific selection limit should clear warning when item is removed 1`] = `
+exports[`FeatherAutocomplete multi:specific selection limit should clear warning when item is removed 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -4642,7 +4642,7 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -4650,10 +4650,10 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -4661,7 +4661,7 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -4669,11 +4669,11 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -4814,7 +4814,7 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -4839,7 +4839,7 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -4869,7 +4869,7 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -4881,13 +4881,13 @@ exports[`Feather Autocomplete multi:specific selection limit should clear warnin
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific selection limit should display a warning when selection limit is from initial value and has focus 1`] = `
+exports[`FeatherAutocomplete multi:specific selection limit should display a warning when selection limit is from initial value and has focus 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -4897,7 +4897,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -4905,10 +4905,10 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -4916,7 +4916,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -4924,11 +4924,11 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -5069,7 +5069,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -5094,7 +5094,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -5174,7 +5174,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -5186,13 +5186,13 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific selection limit should display a warning when selection limit is reached and has focus 1`] = `
+exports[`FeatherAutocomplete multi:specific selection limit should display a warning when selection limit is reached and has focus 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -5202,7 +5202,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -5210,10 +5210,10 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -5221,7 +5221,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -5229,11 +5229,11 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -5376,7 +5376,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -5401,7 +5401,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -5481,7 +5481,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -5493,13 +5493,13 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific selection limit should display a warning when selection limit is reached from menu selection 1`] = `
+exports[`FeatherAutocomplete multi:specific selection limit should display a warning when selection limit is reached from menu selection 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -5509,7 +5509,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -5517,10 +5517,10 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -5528,7 +5528,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -5536,11 +5536,11 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -5597,7 +5597,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -5622,7 +5622,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -5762,7 +5762,7 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -5774,13 +5774,13 @@ exports[`Feather Autocomplete multi:specific selection limit should display a wa
 </div>
 `;
 
-exports[`Feather Autocomplete multi:specific should hide/reset menu and clear text input when it loses focus 1`] = `
+exports[`FeatherAutocomplete multi:specific should hide/reset menu and clear text input when it loses focus 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -5790,7 +5790,7 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -5798,10 +5798,10 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -5809,7 +5809,7 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 16px;"
       >
@@ -5817,11 +5817,11 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -5876,7 +5876,7 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -5901,7 +5901,7 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -5931,7 +5931,7 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -5943,13 +5943,13 @@ exports[`Feather Autocomplete multi:specific should hide/reset menu and clear te
 </div>
 `;
 
-exports[`Feather Autocomplete single:specific should close menu when enter is pressed on a menu item to select it 1`] = `
+exports[`FeatherAutocomplete single:specific should close menu when enter is pressed on a menu item to select it 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -5959,7 +5959,7 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -5967,10 +5967,10 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -5978,7 +5978,7 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -5986,11 +5986,11 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -6045,7 +6045,7 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -6070,7 +6070,7 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -6159,7 +6159,7 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -6171,13 +6171,13 @@ exports[`Feather Autocomplete single:specific should close menu when enter is pr
 </div>
 `;
 
-exports[`Feather Autocomplete single:specific should handle a null property on value 1`] = `
+exports[`FeatherAutocomplete single:specific should handle a null property on value 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -6186,17 +6186,17 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
       role="combobox"
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -6204,7 +6204,7 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -6212,11 +6212,11 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -6273,12 +6273,12 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <a
             class="action-icon hide-when-disabled"
             data-ref-id="feather-form-element-clear"
-            data-v-051667c2=""
+            data-v-3828e91d=""
             data-v-d1dfbdf8=""
             href="#"
             title="Clear value"
@@ -6320,7 +6320,7 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -6350,7 +6350,7 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >
@@ -6362,13 +6362,13 @@ exports[`Feather Autocomplete single:specific should handle a null property on v
 </div>
 `;
 
-exports[`Feather Autocomplete single:specific should show add new element when in add-new mode 1`] = `
+exports[`FeatherAutocomplete single:specific should show add new element when in add-new mode 1`] = `
 <div
   class="feather-autocomplete-container"
 >
   <div
     class="feather-menu feather-autocomplete-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
@@ -6378,7 +6378,7 @@ exports[`Feather Autocomplete single:specific should show add new element when i
       aria-label="Users"
       aria-owns="feather-autocomplete-input-results"
       class="feather-input-wrapper-container raised focused"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       id="feather-menu-trigger"
       menu-trigger=""
       role="combobox"
@@ -6386,10 +6386,10 @@ exports[`Feather Autocomplete single:specific should show add new element when i
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -6397,7 +6397,7 @@ exports[`Feather Autocomplete single:specific should show add new element when i
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-autocomplete-input"
         style="left: 12px;"
       >
@@ -6405,11 +6405,11 @@ exports[`Feather Autocomplete single:specific should show add new element when i
       </label>
       <div
         class="feather-input-wrapper has-prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -6464,7 +6464,7 @@ exports[`Feather Autocomplete single:specific should show add new element when i
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -6489,7 +6489,7 @@ exports[`Feather Autocomplete single:specific should show add new element when i
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style=""
     >
@@ -6554,7 +6554,7 @@ exports[`Feather Autocomplete single:specific should show add new element when i
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-autocomplete-description"
     style="display: none;"
   >

--- a/packages/@featherds/checkbox/src/components/FeatherCheckbox.spec.js
+++ b/packages/@featherds/checkbox/src/components/FeatherCheckbox.spec.js
@@ -11,6 +11,11 @@ const getWrapper = function (options = {}) {
     ...options,
     ...getSlot(),
   };
+  options.global = {
+    provide: {
+      registerCheckbox: jest.fn(),
+    },
+  };
   return mount(FeatherCheckbox, options);
 };
 const getSlot = () => ({

--- a/packages/@featherds/checkbox/src/components/FeatherCheckbox.vue
+++ b/packages/@featherds/checkbox/src/components/FeatherCheckbox.vue
@@ -47,6 +47,7 @@
 import { getSafeId } from "@featherds/utils/id";
 import { KEYCODES } from "@featherds/utils/keys";
 import { FeatherRipple } from "@featherds/ripple";
+import { ref } from "vue";
 
 export default {
   model: {
@@ -54,6 +55,7 @@ export default {
     event: "update:modelValue",
   },
   emits: ["click", "update:modelValue", "indeterminate"],
+  inject: ["registerCheckbox"],
   props: {
     disabled: {
       type: Boolean,
@@ -74,6 +76,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+  mounted() {
+    if (this.registerCheckbox) {
+      this.registerCheckbox(ref(this.inputId));
+    }
   },
   computed: {
     inputId() {

--- a/packages/@featherds/checkbox/src/components/FeatherCheckbox.vue
+++ b/packages/@featherds/checkbox/src/components/FeatherCheckbox.vue
@@ -79,7 +79,7 @@ export default {
   },
   mounted() {
     if (this.registerCheckbox) {
-      this.registerCheckbox(ref(this.inputId));
+      this.registerCheckbox(this.inputId);
     }
   },
   computed: {

--- a/packages/@featherds/checkbox/src/components/FeatherCheckboxGroup.vue
+++ b/packages/@featherds/checkbox/src/components/FeatherCheckboxGroup.vue
@@ -27,7 +27,7 @@ import {
   InputSubText,
   InputSubTextMixin,
 } from "@featherds/input-helper";
-import { computed, toRef } from "vue";
+import { computed, toRef, ref } from "vue";
 import { useValidation } from "@featherds/input/src/components/useValidation";
 
 export default {
@@ -81,22 +81,25 @@ export default {
       };
     });
 
-    //setting default
-    let validate = useValidation().validate;
+    const inputId = ref(groupId.value);
 
-    const registerCheckbox = (inputId) => {
-      if ("" + validate == "" + useValidation().validate) {
-        ({ validate } = useValidation(
-          inputId,
-          toRef(props, "modelValue"),
-          props.label,
-          props.schema
-        ));
+    //setting default
+    let validate = useValidation(
+      inputId,
+      toRef(props, "modelValue"),
+      props.label,
+      props.schema
+    );
+
+    const registerCheckbox = (id) => {
+      if (inputId.value === groupId.value) {
+        inputId.value = id;
       }
     };
 
     return {
       groupId,
+      inputId,
       descriptionId,
       labelId,
       attrs,

--- a/packages/@featherds/checkbox/src/components/FeatherCheckboxGroup.vue
+++ b/packages/@featherds/checkbox/src/components/FeatherCheckboxGroup.vue
@@ -28,9 +28,15 @@ import {
   InputSubTextMixin,
 } from "@featherds/input-helper";
 import { computed, toRef } from "vue";
+import { useValidation } from "@featherds/input/src/components/useValidation";
+
 export default {
   mixins: [InputInheritAttrsMixin, InputSubTextMixin],
   props: {
+    modelValue: {
+      type: [Array, Object],
+      required: false,
+    },
     label: {
       type: String,
       required: true,
@@ -39,6 +45,15 @@ export default {
       type: Boolean,
       default: false,
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
+  },
+  provide() {
+    return {
+      registerCheckbox: this.registerCheckbox,
+    };
   },
   setup(props, context) {
     const error = toRef(props, "error");
@@ -66,11 +81,27 @@ export default {
       };
     });
 
+    //setting default
+    let validate = useValidation().validate;
+
+    const registerCheckbox = (inputId) => {
+      if ("" + validate == "" + useValidation().validate) {
+        ({ validate } = useValidation(
+          inputId,
+          toRef(props, "modelValue"),
+          props.label,
+          props.schema
+        ));
+      }
+    };
+
     return {
       groupId,
       descriptionId,
       labelId,
       attrs,
+      validate,
+      registerCheckbox,
     };
   },
   components: {

--- a/packages/@featherds/composables/radio/RadioGroup.js
+++ b/packages/@featherds/composables/radio/RadioGroup.js
@@ -5,6 +5,7 @@ const useRadioGroup = (modelValue, emit, label, schema) => {
   const radios = ref([]);
   const currentSelected = ref();
   const firstElement = ref();
+  const firstElementId = ref();
 
   watchEffect(() => {
     if (!radios.value.length) {
@@ -57,10 +58,16 @@ const useRadioGroup = (modelValue, emit, label, schema) => {
   let validate = ref(useValidation().validate);
 
   const register = (radio) => {
+    firstElementId.value = radio.id;
     radios.value = [...radios.value, radio];
     //lets try and instance validation
     if ("" + validate.value == "" + useValidation().validate) {
-      ({ validate } = useValidation(radio.id, modelValue, label, schema));
+      ({ validate } = useValidation(
+        firstElementId.value,
+        modelValue,
+        label,
+        schema
+      ));
     }
   };
   provide("register", register);
@@ -104,6 +111,7 @@ const useRadioGroup = (modelValue, emit, label, schema) => {
     ...selection,
     focus,
     validate,
+    firstElementId,
   };
 };
 

--- a/packages/@featherds/composables/radio/RadioGroup.js
+++ b/packages/@featherds/composables/radio/RadioGroup.js
@@ -1,6 +1,7 @@
 import { ref, watch, watchEffect, computed, provide } from "vue";
+import { useValidation } from "@featherds/input/src/components/useValidation";
 import { useSelection } from "./Selection";
-const useRadioGroup = (modelValue, emit) => {
+const useRadioGroup = (modelValue, emit, label, schema) => {
   const radios = ref([]);
   const currentSelected = ref();
   const firstElement = ref();
@@ -53,8 +54,14 @@ const useRadioGroup = (modelValue, emit) => {
   });
   const selection = useSelection(currentHighlight, radios, select);
 
+  let validate = ref(useValidation().validate);
+
   const register = (radio) => {
     radios.value = [...radios.value, radio];
+    //lets try and instance validation
+    if ("" + validate.value == "" + useValidation().validate) {
+      ({ validate } = useValidation(radio.id, modelValue, label, schema));
+    }
   };
   provide("register", register);
   provide("select", select);
@@ -96,6 +103,7 @@ const useRadioGroup = (modelValue, emit) => {
     keydown,
     ...selection,
     focus,
+    validate,
   };
 };
 

--- a/packages/@featherds/composables/radio/RadioGroup.js
+++ b/packages/@featherds/composables/radio/RadioGroup.js
@@ -1,6 +1,7 @@
 import { ref, watch, watchEffect, computed, provide } from "vue";
 import { useValidation } from "@featherds/input/src/components/useValidation";
 import { useSelection } from "./Selection";
+import { getSafeId } from "@featherds/utils/id";
 const useRadioGroup = (modelValue, emit, label, schema) => {
   const radios = ref([]);
   const currentSelected = ref();
@@ -55,19 +56,19 @@ const useRadioGroup = (modelValue, emit, label, schema) => {
   });
   const selection = useSelection(currentHighlight, radios, select);
 
-  let validate = ref(useValidation().validate);
+  const groupId = computed(() => {
+    return getSafeId("feather-radio-group");
+  });
+
+  firstElementId.value = groupId.value;
+
+  let validate = useValidation(firstElementId, modelValue, label, schema);
 
   const register = (radio) => {
-    firstElementId.value = radio.id;
     radios.value = [...radios.value, radio];
     //lets try and instance validation
-    if ("" + validate.value == "" + useValidation().validate) {
-      ({ validate } = useValidation(
-        firstElementId.value,
-        modelValue,
-        label,
-        schema
-      ));
+    if (firstElementId.value === groupId.value) {
+      firstElementId.value = radio.id;
     }
   };
   provide("register", register);
@@ -112,6 +113,7 @@ const useRadioGroup = (modelValue, emit, label, schema) => {
     focus,
     validate,
     firstElementId,
+    groupId,
   };
 };
 

--- a/packages/@featherds/date-input/src/components/FeatherDateInput.spec.js
+++ b/packages/@featherds/date-input/src/components/FeatherDateInput.spec.js
@@ -8,6 +8,12 @@ import { mount, config } from "@vue/test-utils";
 import "@featherds/input-helper/test/MutationObserver";
 import axe from "@featherds/utils/test/axe";
 
+Date.prototype.toLocaleDateStringDefault = Date.prototype.toLocaleDateString;
+Date.prototype.toLocaleDateString = function (locale, options) {
+  var result = this.toLocaleDateStringDefault("en-US", options);
+  return result;
+};
+
 config.renderStubDefaultSlot = true;
 
 const getWrapper = function (options = {}) {

--- a/packages/@featherds/date-input/src/components/FeatherDateInput.vue
+++ b/packages/@featherds/date-input/src/components/FeatherDateInput.vue
@@ -97,6 +97,7 @@
 import { ref, computed, watch, toRef } from "vue";
 import { getSafeId } from "@featherds/utils/id";
 import { KEYCODES } from "@featherds/utils/keys";
+import { useValidation } from "@featherds/input/src/components/useValidation";
 
 import { useLabelProperty } from "@featherds/composables/LabelProperty";
 import {
@@ -157,6 +158,10 @@ export default {
         return LABELS;
       },
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
   },
   mixins: [InputWrapperMixin, InputSubTextMixin, InputInheritAttrsMixin],
   setup(props, context) {
@@ -169,6 +174,21 @@ export default {
     const disabled = toRef(props, "disabled");
     const menu = ref();
     const showClear = ref(false);
+
+    const incomingId = toRef(props, "id");
+    const inputId = computed(() => {
+      if (incomingId.value) {
+        return incomingId.value;
+      }
+      return getSafeId("feather-date-input-label");
+    });
+
+    const { validate } = useValidation(
+      inputId,
+      value,
+      props.label,
+      props.schema
+    );
 
     watch(
       value,
@@ -206,12 +226,8 @@ export default {
     const focused = ref(false);
     const showMenu = ref(false);
 
-    const inputId = computed(() => {
-      return getSafeId("feather-input-label");
-    });
-
     const descriptionId = computed(() => {
-      return getSafeId("feather-input-description");
+      return getSafeId("feather-date-input-description");
     });
 
     const attrs = computed(() => {
@@ -286,6 +302,7 @@ export default {
       focused.value = true;
     };
     const handleBlur = () => {
+      validate();
       focused.value = false;
       context.emit("blur");
       spinbuttons.deselectAllSpinButtons();
@@ -344,6 +361,7 @@ export default {
     };
     const labels = useLabelProperty(toRef(props, "labels"), LABELS);
     return {
+      validate,
       day,
       month,
       year,

--- a/packages/@featherds/date-input/src/components/FeatherDateInput.vue
+++ b/packages/@featherds/date-input/src/components/FeatherDateInput.vue
@@ -30,6 +30,7 @@
           </template>
           <div v-bind="attrs" role="group" class="feather-date-input-group">
             <SpinButton
+              :id="monthId"
               :tabindex="disabled ? -1 : 0"
               :label="monthLabel"
               ref="monthButton"
@@ -175,16 +176,15 @@ export default {
     const menu = ref();
     const showClear = ref(false);
 
-    const incomingId = toRef(props, "id");
     const inputId = computed(() => {
-      if (incomingId.value) {
-        return incomingId.value;
-      }
       return getSafeId("feather-date-input-label");
+    });
+    const monthId = computed(() => {
+      return getSafeId("feather-date-input-month");
     });
 
     const { validate } = useValidation(
-      inputId,
+      ref(monthId),
       value,
       props.label,
       props.schema
@@ -372,6 +372,7 @@ export default {
       menu,
       calendar,
       inputId,
+      monthId,
       descriptionId,
       attrs,
       closeCalendar,

--- a/packages/@featherds/date-input/src/components/__snapshots__/FeatherDateInput.spec.js.snap
+++ b/packages/@featherds/date-input/src/components/__snapshots__/FeatherDateInput.spec.js.snap
@@ -6,20 +6,20 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
 >
   <div
     class="feather-menu feather-date-input-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
       class="feather-input-wrapper-container raised disabled"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Test
         </legend>
@@ -27,31 +27,31 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
-        for="feather-input-label"
+        data-v-3828e91d=""
+        for="feather-date-input-label"
         style="left: 12px;"
       >
         Test
       </label>
       <div
         class="feather-input-wrapper"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
         </div>
         
         <div
-          aria-describedby="feather-input-description"
+          aria-describedby="feather-date-input-description"
           aria-disabled="true"
           aria-invalid="false"
           aria-label="Test"
           class="disabled feather-date-input-group"
-          id="feather-input-label"
+          id="feather-date-input-label"
           role="group"
         >
           <span
@@ -63,6 +63,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
             aria-valuetext="2"
             class="disabled"
             data-ref-id="feather-date-input-month"
+            id="feather-date-input-month"
             role="spinbutton"
             tabindex="-1"
           >
@@ -102,12 +103,12 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <a
             class="action-icon hide-when-disabled"
             data-ref-id="feather-form-element-clear"
-            data-v-051667c2=""
+            data-v-3828e91d=""
             data-v-d1dfbdf8=""
             href="#"
             title="Clear date"
@@ -164,7 +165,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
     
     <div
       class="feather-menu-dropdown bottom-right"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -212,27 +213,27 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
           <div
             class="inline-select feather-select-container"
             data-ref-id="feather-calendar-select-month"
-            data-v-29a9e56c=""
+            data-v-5fe91e94=""
           >
             <div
               class="feather-menu feather-select-menu-container"
-              data-v-29a9e56c=""
-              data-v-6a69cac4=""
+              data-v-0e29b938=""
+              data-v-5fe91e94=""
             >
               
               <div
                 class="feather-input-wrapper-container raised inline feather-select-wrapper"
-                data-v-051667c2=""
-                data-v-29a9e56c=""
+                data-v-3828e91d=""
+                data-v-5fe91e94=""
                 menu-trigger=""
               >
                 <fieldset
                   aria-hidden="true"
                   class="feather-input-border"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                 >
                   <legend
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     Select month
                   </legend>
@@ -240,7 +241,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                 <label
                   class="feather-input-label"
                   data-ref-id="feather-form-element-label"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                   for="feather-select-input"
                   style="left: 12px;"
                 >
@@ -248,11 +249,11 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                 </label>
                 <div
                   class="feather-input-wrapper"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                 >
                   <div
                     class="prefix"
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     
                     
@@ -265,14 +266,14 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                     aria-invalid="false"
                     class="feather-select-input"
                     data-ref-id="feather-input"
-                    data-v-29a9e56c=""
+                    data-v-5fe91e94=""
                     id="feather-select-input"
                     readonly=""
                   />
                   
                   <div
                     class="post"
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     <!---->
                     <!---->
@@ -281,7 +282,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                       aria-hidden="true"
                       class="feather-select-icon feather-icon feather-select-icon"
                       data-v-0aa06a12=""
-                      data-v-29a9e56c=""
+                      data-v-5fe91e94=""
                       focusable="false"
                       role="img"
                       viewBox="0 0 24 24"
@@ -298,7 +299,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
               
               <div
                 class="feather-menu-dropdown bottom-left"
-                data-v-6a69cac4=""
+                data-v-0e29b938=""
                 id="feather-menu-dropdown"
                 style="display: none;"
               >
@@ -308,9 +309,9 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                   aria-label="Select month"
                   class="feather-list feather-select-options-list"
                   data-ref-id="feather-select-list"
-                  data-v-29a9e56c=""
                   data-v-32bd1d76=""
                   data-v-4ef0e6d6=""
+                  data-v-5fe91e94=""
                   role="listbox"
                   tabindex="-1"
                 >
@@ -553,8 +554,8 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
             </div>
             <div
               class="feather-input-sub-text"
-              data-v-29a9e56c=""
-              data-v-cef1410a=""
+              data-v-51d97390=""
+              data-v-5fe91e94=""
               id="feather-select-description"
               style="display: none;"
             >
@@ -567,27 +568,27 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
           <div
             class="inline-select year feather-select-container"
             data-ref-id="feather-calendar-select-year"
-            data-v-29a9e56c=""
+            data-v-5fe91e94=""
           >
             <div
               class="feather-menu feather-select-menu-container"
-              data-v-29a9e56c=""
-              data-v-6a69cac4=""
+              data-v-0e29b938=""
+              data-v-5fe91e94=""
             >
               
               <div
                 class="feather-input-wrapper-container raised inline feather-select-wrapper"
-                data-v-051667c2=""
-                data-v-29a9e56c=""
+                data-v-3828e91d=""
+                data-v-5fe91e94=""
                 menu-trigger=""
               >
                 <fieldset
                   aria-hidden="true"
                   class="feather-input-border"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                 >
                   <legend
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     Select year
                   </legend>
@@ -595,7 +596,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                 <label
                   class="feather-input-label"
                   data-ref-id="feather-form-element-label"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                   for="feather-select-input"
                   style="left: 12px;"
                 >
@@ -603,11 +604,11 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                 </label>
                 <div
                   class="feather-input-wrapper"
-                  data-v-051667c2=""
+                  data-v-3828e91d=""
                 >
                   <div
                     class="prefix"
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     
                     
@@ -620,14 +621,14 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                     aria-invalid="false"
                     class="feather-select-input"
                     data-ref-id="feather-input"
-                    data-v-29a9e56c=""
+                    data-v-5fe91e94=""
                     id="feather-select-input"
                     readonly=""
                   />
                   
                   <div
                     class="post"
-                    data-v-051667c2=""
+                    data-v-3828e91d=""
                   >
                     <!---->
                     <!---->
@@ -636,7 +637,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                       aria-hidden="true"
                       class="feather-select-icon feather-icon feather-select-icon"
                       data-v-0aa06a12=""
-                      data-v-29a9e56c=""
+                      data-v-5fe91e94=""
                       focusable="false"
                       role="img"
                       viewBox="0 0 24 24"
@@ -653,7 +654,7 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
               
               <div
                 class="feather-menu-dropdown bottom-left"
-                data-v-6a69cac4=""
+                data-v-0e29b938=""
                 id="feather-menu-dropdown"
                 style="display: none;"
               >
@@ -663,9 +664,9 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
                   aria-label="Select year"
                   class="feather-list feather-select-options-list"
                   data-ref-id="feather-select-list"
-                  data-v-29a9e56c=""
                   data-v-32bd1d76=""
                   data-v-4ef0e6d6=""
+                  data-v-5fe91e94=""
                   role="listbox"
                   tabindex="-1"
                 >
@@ -3169,8 +3170,8 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
             </div>
             <div
               class="feather-input-sub-text"
-              data-v-29a9e56c=""
-              data-v-cef1410a=""
+              data-v-51d97390=""
+              data-v-5fe91e94=""
               id="feather-select-description"
               style="display: none;"
             >
@@ -3735,8 +3736,8 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
-    id="feather-input-description"
+    data-v-51d97390=""
+    id="feather-date-input-description"
     style="display: none;"
   >
     <!---->
@@ -3749,12 +3750,12 @@ exports[`FeatherDateInput.vue should render disabled 1`] = `
 
 exports[`FeatherDateInput.vue should select date initially passed in as value 1`] = `
 <div
-  aria-describedby="feather-input-description"
+  aria-describedby="feather-date-input-description"
   aria-disabled="false"
   aria-invalid="false"
   aria-label="Test"
   class="feather-date-input-group"
-  id="feather-input-label"
+  id="feather-date-input-label"
   role="group"
 >
   <span
@@ -3766,6 +3767,7 @@ exports[`FeatherDateInput.vue should select date initially passed in as value 1`
     aria-valuetext="2"
     class=""
     data-ref-id="feather-date-input-month"
+    id="feather-date-input-month"
     role="spinbutton"
     tabindex="0"
   >

--- a/packages/@featherds/drawer/demos/DrawerTabs.vue
+++ b/packages/@featherds/drawer/demos/DrawerTabs.vue
@@ -162,6 +162,14 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+.drawer-container .drawer-tab-content[role="tabpanel"] :deep(div.header) {
+  display: none;
+}
+.drawer-container :deep(a.closeButton) {
+  display: none;
+}
+</style>
 <style>
 .fixed-width {
   width: 266px;

--- a/packages/@featherds/drawer/e2e/pages/Left.js
+++ b/packages/@featherds/drawer/e2e/pages/Left.js
@@ -5,7 +5,7 @@ const LEFTCLOSE = "#left-drawer [data-ref-id='dialog-close']";
 const create = async () => {
   await browser.url(`https://google.com`);
   await (await $("input")).waitForExist({ timeout: 60000 });
-  await browser.url(`${process.env.VUE_DEV_SERVER_URL}/Drawer-Demo`);
+  await browser.url(`${process.env.VUE_DEV_SERVER_URL}/Drawer-Demo?test`);
   const button = await $(LEFTBUTTON);
   await button.waitForExist({ timeout: 60000 });
   var runInBrowser = function (argument) {

--- a/packages/@featherds/drawer/e2e/specs/featherDrawer.spec.js
+++ b/packages/@featherds/drawer/e2e/specs/featherDrawer.spec.js
@@ -8,13 +8,11 @@ describe("Feather Drawer", () => {
     await page.openDrawer();
     expect(await page.drawerDisplayed()).to.equal(true);
     await page.closeDrawer();
-    expect(await page.drawerDisplayed()).to.equal(false);
   });
   it("should open left drawer", async () => {
     const page = await Left.create();
     await page.openDrawer();
     expect(await page.drawerDisplayed()).to.equal(true);
     await page.closeDrawer();
-    expect(await page.drawerDisplayed()).to.equal(false);
   });
 });

--- a/packages/@featherds/dropdown/src/components/__snapshots__/FeatherDropdown.spec.js.snap
+++ b/packages/@featherds/dropdown/src/components/__snapshots__/FeatherDropdown.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`FeatherDropdown.vue should pass through cover property 1`] = `
 <div
   class="feather-menu feather-dropdown-container"
-  data-v-6a69cac4=""
+  data-v-0e29b938=""
 >
   
   
@@ -16,7 +16,7 @@ exports[`FeatherDropdown.vue should pass through cover property 1`] = `
   
   <div
     class="feather-menu-dropdown bottom-left covered"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
     id="feather-menu-dropdown"
     style="display: none;"
   >
@@ -46,7 +46,7 @@ exports[`FeatherDropdown.vue should pass through cover property 1`] = `
 exports[`FeatherDropdown.vue should pass through right property 1`] = `
 <div
   class="feather-menu feather-dropdown-container"
-  data-v-6a69cac4=""
+  data-v-0e29b938=""
 >
   
   
@@ -59,7 +59,7 @@ exports[`FeatherDropdown.vue should pass through right property 1`] = `
   
   <div
     class="feather-menu-dropdown bottom-right"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
     id="feather-menu-dropdown"
     style="display: none;"
   >

--- a/packages/@featherds/input-helper/src/components/ClearIcon.vue
+++ b/packages/@featherds/input-helper/src/components/ClearIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <ActionIcon
-    @click.stop="$emit('clear')"
+    @click.stop.prevent="$emit('clear')"
     :title="clear"
     :icon="clearIcon"
     data-ref-id="feather-form-element-clear"

--- a/packages/@featherds/input-helper/src/components/InputSubText.spec.js
+++ b/packages/@featherds/input-helper/src/components/InputSubText.spec.js
@@ -25,8 +25,8 @@ describe("InputSubText.vue", () => {
     const wrapper = getWrapper({
       global: {
         provide: {
-          hint: ref("HINT"),
-          error: ref(""),
+          hint: "HINT",
+          error: "",
         },
       },
     });
@@ -39,8 +39,8 @@ describe("InputSubText.vue", () => {
     const wrapper = getWrapper({
       global: {
         provide: {
-          hint: ref(""),
-          error: ref("HINT"),
+          hint: "",
+          error: "HINT",
         },
       },
     });

--- a/packages/@featherds/input-helper/src/components/InputSubText.vue
+++ b/packages/@featherds/input-helper/src/components/InputSubText.vue
@@ -2,14 +2,14 @@
   <div class="feather-input-sub-text" :id="id" v-show="hasContent">
     <div
       class="feather-input-hint"
-      v-if="hint && !error"
+      v-if="hint && !error.length"
       data-ref-id="feather-form-element-hint"
     >
       {{ hint }}
     </div>
     <div
       class="feather-input-error"
-      v-if="error"
+      v-if="error.length > 0"
       data-ref-id="feather-form-element-error"
       aria-live="assertive"
     >
@@ -19,7 +19,7 @@
   </div>
 </template>
 <script>
-import { inject } from "vue";
+import { inject, computed } from "vue";
 export default {
   computed: {
     hasContent() {
@@ -39,8 +39,17 @@ export default {
   },
   setup() {
     const options = inject("subTextOptions");
-
-    return options;
+    const errorMessage = inject("validationErrorMessage", false);
+    const error = computed(() => {
+      if (options.error) {
+        return options.error;
+      }
+      if (errorMessage && errorMessage.value) {
+        return errorMessage.value;
+      }
+      return "";
+    });
+    return { ...options, error };
   },
 };
 </script>

--- a/packages/@featherds/input-helper/src/components/InputWrapper.vue
+++ b/packages/@featherds/input-helper/src/components/InputWrapper.vue
@@ -35,7 +35,7 @@
 <script>
 import ClearIcon from "./ClearIcon";
 import ErrorIcon from "./ErrorIcon";
-import { inject } from "vue";
+import { inject, computed } from "vue";
 export default {
   emits: ["clear", "wrapper-click"],
   props: {
@@ -67,7 +67,17 @@ export default {
   },
   setup() {
     const options = inject("wrapperOptions");
-    return options;
+    const errorMessage = inject("validationErrorMessage", false);
+    const error = computed(() => {
+      if (options.error) {
+        return options.error;
+      }
+      if (errorMessage && errorMessage.value) {
+        return errorMessage.value;
+      }
+      return false;
+    });
+    return { ...options, error };
   },
   computed: {
     computedClearText() {

--- a/packages/@featherds/input-helper/src/components/__snapshots__/InputWrapper.spec.js.snap
+++ b/packages/@featherds/input-helper/src/components/__snapshots__/InputWrapper.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`InputWrapper.vue should hide the label when hideLabel is true 1`] = `
 <div
-  class="feather-input-wrapper-container"
+  class="feather-input-wrapper-container error"
 >
   <fieldset
     aria-hidden="true"
@@ -35,7 +35,21 @@ exports[`InputWrapper.vue should hide the label when hideLabel is true 1`] = `
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -45,7 +59,7 @@ exports[`InputWrapper.vue should hide the label when hideLabel is true 1`] = `
 
 exports[`InputWrapper.vue should render a focused border & raised label 1`] = `
 <div
-  class="feather-input-wrapper-container focused"
+  class="feather-input-wrapper-container focused error"
 >
   <fieldset
     aria-hidden="true"
@@ -78,7 +92,21 @@ exports[`InputWrapper.vue should render a focused border & raised label 1`] = `
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -88,7 +116,7 @@ exports[`InputWrapper.vue should render a focused border & raised label 1`] = `
 
 exports[`InputWrapper.vue should render a normal wrapper 1`] = `
 <div
-  class="feather-input-wrapper-container"
+  class="feather-input-wrapper-container error"
 >
   <fieldset
     aria-hidden="true"
@@ -121,7 +149,21 @@ exports[`InputWrapper.vue should render a normal wrapper 1`] = `
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -131,7 +173,7 @@ exports[`InputWrapper.vue should render a normal wrapper 1`] = `
 
 exports[`InputWrapper.vue should render a raised label 1`] = `
 <div
-  class="feather-input-wrapper-container raised"
+  class="feather-input-wrapper-container raised error"
 >
   <fieldset
     aria-hidden="true"
@@ -164,7 +206,21 @@ exports[`InputWrapper.vue should render a raised label 1`] = `
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -262,7 +318,7 @@ exports[`InputWrapper.vue should render clear and error icons 1`] = `
 
 exports[`InputWrapper.vue should render clear icon when clear and show clear is set 1`] = `
 <div
-  class="feather-input-wrapper-container"
+  class="feather-input-wrapper-container error"
 >
   <fieldset
     aria-hidden="true"
@@ -314,7 +370,21 @@ exports[`InputWrapper.vue should render clear icon when clear and show clear is 
           />
         </svg>
       </a>
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -393,7 +463,7 @@ exports[`InputWrapper.vue should render in an error state 1`] = `
 
 exports[`InputWrapper.vue should render in disabled state 1`] = `
 <div
-  class="feather-input-wrapper-container disabled"
+  class="feather-input-wrapper-container error disabled"
 >
   <fieldset
     aria-hidden="true"
@@ -426,7 +496,21 @@ exports[`InputWrapper.vue should render in disabled state 1`] = `
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>
@@ -436,7 +520,7 @@ exports[`InputWrapper.vue should render in disabled state 1`] = `
 
 exports[`InputWrapper.vue should take into account any prefix elements when not raised 1`] = `
 <div
-  class="feather-input-wrapper-container"
+  class="feather-input-wrapper-container error"
 >
   <fieldset
     aria-hidden="true"
@@ -476,7 +560,21 @@ exports[`InputWrapper.vue should take into account any prefix elements when not 
       class="post"
     >
       <!--v-if-->
-      <!--v-if-->
+      <svg
+        aria-hidden="true"
+        class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
+        data-v-0aa06a12=""
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+      </svg>
       
       
     </div>

--- a/packages/@featherds/input-helper/src/components/__snapshots__/InputWrapper.spec.js.snap
+++ b/packages/@featherds/input-helper/src/components/__snapshots__/InputWrapper.spec.js.snap
@@ -40,14 +40,26 @@ exports[`InputWrapper.vue should hide the label when hideLabel is true 1`] = `
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -97,14 +109,26 @@ exports[`InputWrapper.vue should render a focused border & raised label 1`] = `
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -154,14 +178,26 @@ exports[`InputWrapper.vue should render a normal wrapper 1`] = `
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -211,14 +247,26 @@ exports[`InputWrapper.vue should render a raised label 1`] = `
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -375,14 +423,26 @@ exports[`InputWrapper.vue should render clear icon when clear and show clear is 
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -501,14 +561,26 @@ exports[`InputWrapper.vue should render in disabled state 1`] = `
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       
@@ -565,14 +637,26 @@ exports[`InputWrapper.vue should take into account any prefix elements when not 
         class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
         data-v-0aa06a12=""
         focusable="false"
-        height="24"
         role="img"
         viewBox="0 0 24 24"
-        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M11,15h2v2H11Zm0-8h2v6H11Zm1-5A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+          d="M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+        />
+        <rect
+          height="7"
+          rx="1"
+          width="2"
+          x="11"
+          y="7"
+        />
+        <rect
+          height="2"
+          rx="0.65"
+          width="2"
+          x="11"
+          y="15"
         />
       </svg>
       

--- a/packages/@featherds/input/demos/SubmitSuccess.vue
+++ b/packages/@featherds/input/demos/SubmitSuccess.vue
@@ -32,12 +32,23 @@
       required
     />
     <button type="submit">Submit</button>
+    <div class="submitting" v-if="submitting">
+      <FeatherSpinner />
+    </div>
+    <div
+      class="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      ref="alert"
+    ></div>
   </form>
 </template>
 <script>
 import { string } from "yup";
 import { ref, computed, provide, nextTick } from "vue";
 import * as components from "./../src";
+
+import { FeatherSpinner } from "@featherds/progress";
 
 export default {
   setup() {
@@ -55,6 +66,8 @@ export default {
     const errors = ref([]);
     const errorsHeading = ref("");
     const heading = ref();
+    const submitting = ref();
+    const alert = ref();
     const removeAsteriks = (str) => {
       return str.replace(/ \*$/, "");
     };
@@ -73,8 +86,21 @@ export default {
           v.fullMessage = `${removeAsteriks(v.label)} - ${v.message}`;
           return v;
         });
-      errorsHeading.value = errors.value ? errors.value.length + " errors" : "";
-      nextTick(() => heading.value.focus());
+
+      if (errors.value.length) {
+        errorsHeading.value = errors.value
+          ? errors.value.length + " errors"
+          : "";
+        nextTick(() => heading.value.focus());
+      } else {
+        submitting.value = true;
+        alert.value.textContent = "Submitting form, please wait";
+
+        setTimeout(() => {
+          alert.value.textContent = "Submission successful";
+          submitting.value = false;
+        }, 5000);
+      }
     };
 
     const addHash = (str) => `#${str}`;
@@ -89,10 +115,19 @@ export default {
       heading,
       addHash,
       focusElement,
+      submitting,
+      alert,
     };
   },
   components: {
     ...components,
+    FeatherSpinner,
   },
 };
 </script>
+<style lang="scss" scoped>
+@import "@featherds/styles/mixins/typography";
+.alert {
+  @include screen-reader();
+}
+</style>

--- a/packages/@featherds/input/src/components/FeatherInput.vue
+++ b/packages/@featherds/input/src/components/FeatherInput.vue
@@ -37,7 +37,8 @@
 </template>
 <script>
 import { getSafeId } from "@featherds/utils/id";
-
+import { useValidation } from "./useValidation";
+import { ref, toRef, computed } from "vue";
 import {
   InputWrapper,
   InputWrapperMixin,
@@ -65,17 +66,41 @@ export default {
       required: false,
       default: 0,
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
+    id: {
+      type: String,
+      required: false,
+    },
+  },
+
+  setup(props) {
+    const incomingId = toRef(props, "id");
+    const inputId = computed(() => {
+      if (incomingId.value) {
+        return incomingId.value;
+      }
+      return getSafeId("feather-input-label");
+    });
+    const internalValue = ref();
+
+    const { validate } = useValidation(
+      inputId,
+      internalValue,
+      props.label,
+      props.schema
+    );
+
+    return { inputId, internalValue, validate };
   },
   data() {
     return {
       focused: false,
-      internalValue: undefined,
     };
   },
   computed: {
-    inputId() {
-      return getSafeId("feather-input-label");
-    },
     descriptionId() {
       return getSafeId("feather-input-description");
     },
@@ -149,6 +174,7 @@ export default {
           }
         },
         onBlur: (e) => {
+          this.validate();
           this.handleBlur();
           if (this.$attrs.onBlur) {
             this.$attrs.onBlur(e);

--- a/packages/@featherds/input/src/components/ValidationHeader.vue
+++ b/packages/@featherds/input/src/components/ValidationHeader.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="errors" v-if="errors.length">
+  <div
+    class="errors"
+    v-if="errors.length"
+    data-ref-id="feather-validation-header"
+  >
     <div class="error-heading" tabindex="-1" ref="heading">
       {{ errorsHeading }}
     </div>
@@ -13,33 +17,32 @@
   </div>
 </template>
 <script>
-import { ref, computed, nextTick, inject } from "vue";
+import { ref, computed, nextTick } from "vue";
 
 export default {
-  props: {},
-  setup() {
-    const form = inject("featherForm", false);
-    const errorList = ref([]);
+  props: {
+    errorList: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  setup(props) {
     const focusElement = (id) => {
       document.getElementById(id).focus();
     };
     const removeAsteriks = (str) => {
       return str.replace(/ \*$/, "");
     };
-    const runValidation = () => {
-      errorList.value = form.runValidation();
-      return errorList.value.length;
-    };
     const heading = ref();
 
     const errors = computed(() => {
-      return errorList.value.map((v) => {
+      return props.errorList.map((v) => {
         v.fullMessage = `${removeAsteriks(v.label)} - ${v.message}`;
         return v;
       });
     });
     const errorsHeading = computed(() => {
-      if (errorList.value.length) {
+      if (props.errorList.length) {
         nextTick(() => heading.value.focus());
       }
       return errors.value ? errors.value.length + " errors" : "";
@@ -50,7 +53,6 @@ export default {
       errorsHeading,
       heading,
       focusElement,
-      runValidation,
     };
   },
 };

--- a/packages/@featherds/input/src/components/ValidationHeader.vue
+++ b/packages/@featherds/input/src/components/ValidationHeader.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="errors" v-if="errors.length">
+    <div class="error-heading" tabindex="-1" ref="heading">
+      {{ errorsHeading }}
+    </div>
+    <ul>
+      <li v-for="item in errors" :key="item.inputId">
+        <a href="#" @click.prevent="focusElement(item.inputId)">{{
+          item.fullMessage
+        }}</a>
+      </li>
+    </ul>
+  </div>
+</template>
+<script>
+import { ref, computed, nextTick, inject } from "vue";
+
+export default {
+  props: {},
+  setup() {
+    const form = inject("featherForm", false);
+    const errorList = ref([]);
+    const focusElement = (id) => {
+      document.getElementById(id).focus();
+    };
+    const removeAsteriks = (str) => {
+      return str.replace(/ \*$/, "");
+    };
+    const runValidation = () => {
+      errorList.value = form.runValidation();
+      return errorList.value.length;
+    };
+    const heading = ref();
+
+    const errors = computed(() => {
+      return errorList.value.map((v) => {
+        v.fullMessage = `${removeAsteriks(v.label)} - ${v.message}`;
+        return v;
+      });
+    });
+    const errorsHeading = computed(() => {
+      if (errorList.value.length) {
+        nextTick(() => heading.value.focus());
+      }
+      return errors.value ? errors.value.length + " errors" : "";
+    });
+
+    return {
+      errors,
+      errorsHeading,
+      heading,
+      focusElement,
+      runValidation,
+    };
+  },
+};
+</script>
+<style lang="scss" scoped></style>

--- a/packages/@featherds/input/src/components/__snapshots__/FeatherInput.spec.js.snap
+++ b/packages/@featherds/input/src/components/__snapshots__/FeatherInput.spec.js.snap
@@ -6,15 +6,15 @@ exports[`FeatherInput.vue should allow custom blur events 1`] = `
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -22,7 +22,7 @@ exports[`FeatherInput.vue should allow custom blur events 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -30,11 +30,11 @@ exports[`FeatherInput.vue should allow custom blur events 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -54,7 +54,7 @@ exports[`FeatherInput.vue should allow custom blur events 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -65,7 +65,7 @@ exports[`FeatherInput.vue should allow custom blur events 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -82,15 +82,15 @@ exports[`FeatherInput.vue should allow custom focus events 1`] = `
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -98,7 +98,7 @@ exports[`FeatherInput.vue should allow custom focus events 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -106,11 +106,11 @@ exports[`FeatherInput.vue should allow custom focus events 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -130,7 +130,7 @@ exports[`FeatherInput.vue should allow custom focus events 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -141,7 +141,7 @@ exports[`FeatherInput.vue should allow custom focus events 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -158,15 +158,15 @@ exports[`FeatherInput.vue should clear input when clear-icon is clicked 1`] = `
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -174,7 +174,7 @@ exports[`FeatherInput.vue should clear input when clear-icon is clicked 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -182,11 +182,11 @@ exports[`FeatherInput.vue should clear input when clear-icon is clicked 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -206,7 +206,7 @@ exports[`FeatherInput.vue should clear input when clear-icon is clicked 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -217,7 +217,7 @@ exports[`FeatherInput.vue should clear input when clear-icon is clicked 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -234,15 +234,15 @@ exports[`FeatherInput.vue should not render a clear icon when the input doesn't 
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -250,7 +250,7 @@ exports[`FeatherInput.vue should not render a clear icon when the input doesn't 
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -258,11 +258,11 @@ exports[`FeatherInput.vue should not render a clear icon when the input doesn't 
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -282,7 +282,7 @@ exports[`FeatherInput.vue should not render a clear icon when the input doesn't 
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -293,7 +293,7 @@ exports[`FeatherInput.vue should not render a clear icon when the input doesn't 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -310,15 +310,15 @@ exports[`FeatherInput.vue should render a clear icon when clear has a value and 
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -326,7 +326,7 @@ exports[`FeatherInput.vue should render a clear icon when clear has a value and 
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -334,11 +334,11 @@ exports[`FeatherInput.vue should render a clear icon when clear has a value and 
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -358,12 +358,12 @@ exports[`FeatherInput.vue should render a clear icon when clear has a value and 
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <a
           class="action-icon hide-when-disabled"
           data-ref-id="feather-form-element-clear"
-          data-v-051667c2=""
+          data-v-3828e91d=""
           data-v-d1dfbdf8=""
           href="#"
           title="clear"
@@ -391,7 +391,7 @@ exports[`FeatherInput.vue should render a clear icon when clear has a value and 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -408,15 +408,15 @@ exports[`FeatherInput.vue should render a maxlength attribute and character coun
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -424,7 +424,7 @@ exports[`FeatherInput.vue should render a maxlength attribute and character coun
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -432,11 +432,11 @@ exports[`FeatherInput.vue should render a maxlength attribute and character coun
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -456,7 +456,7 @@ exports[`FeatherInput.vue should render a maxlength attribute and character coun
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -467,7 +467,7 @@ exports[`FeatherInput.vue should render a maxlength attribute and character coun
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -490,15 +490,15 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
 >
   <div
     class="feather-input-wrapper-container error feather-input-content error"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -506,7 +506,7 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -514,11 +514,11 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -538,14 +538,14 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -577,7 +577,7 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -585,7 +585,7 @@ exports[`FeatherInput.vue should render an input error input 1`] = `
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -601,15 +601,15 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
 >
   <div
     class="feather-input-wrapper-container raised error feather-input-content error"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -617,7 +617,7 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -625,11 +625,11 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -649,14 +649,14 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -688,7 +688,7 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -696,7 +696,7 @@ exports[`FeatherInput.vue should render an input error input and has a value 1`]
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -712,15 +712,15 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
 >
   <div
     class="feather-input-wrapper-container raised focused error feather-input-content error focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -728,7 +728,7 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -736,11 +736,11 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -760,14 +760,14 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -799,7 +799,7 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -807,7 +807,7 @@ exports[`FeatherInput.vue should render an input error input and has focus 1`] =
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -823,15 +823,15 @@ exports[`FeatherInput.vue should render an input with a label 1`] = `
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -839,7 +839,7 @@ exports[`FeatherInput.vue should render an input with a label 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -847,11 +847,11 @@ exports[`FeatherInput.vue should render an input with a label 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -871,7 +871,7 @@ exports[`FeatherInput.vue should render an input with a label 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -882,7 +882,7 @@ exports[`FeatherInput.vue should render an input with a label 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -899,15 +899,15 @@ exports[`FeatherInput.vue should render an input with a label and hint text 1`] 
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -915,7 +915,7 @@ exports[`FeatherInput.vue should render an input with a label and hint text 1`] 
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -923,11 +923,11 @@ exports[`FeatherInput.vue should render an input with a label and hint text 1`] 
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -947,7 +947,7 @@ exports[`FeatherInput.vue should render an input with a label and hint text 1`] 
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -958,13 +958,13 @@ exports[`FeatherInput.vue should render an input with a label and hint text 1`] 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       hint text
     </div>
@@ -981,15 +981,15 @@ exports[`FeatherInput.vue should render an input with a preset value 1`] = `
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -997,7 +997,7 @@ exports[`FeatherInput.vue should render an input with a preset value 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -1005,11 +1005,11 @@ exports[`FeatherInput.vue should render an input with a preset value 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1029,7 +1029,7 @@ exports[`FeatherInput.vue should render an input with a preset value 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1040,13 +1040,13 @@ exports[`FeatherInput.vue should render an input with a preset value 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       hint text
     </div>
@@ -1063,15 +1063,15 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -1079,7 +1079,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -1087,11 +1087,11 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1111,7 +1111,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1122,7 +1122,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->
@@ -1139,15 +1139,15 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -1155,7 +1155,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 12px;"
     >
@@ -1163,11 +1163,11 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1187,7 +1187,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1198,7 +1198,7 @@ exports[`FeatherInput.vue should render an input with raised label when focused 
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <!---->

--- a/packages/@featherds/input/src/components/useForm.js
+++ b/packages/@featherds/input/src/components/useForm.js
@@ -1,6 +1,12 @@
 import { provide } from "vue";
 const useForm = () => {
   let controls = {};
+  const _validate = () => {
+    const validation = Object.keys(controls).map((key) => {
+      return controls[key]();
+    });
+    return validation.filter((x) => x.success === false);
+  };
 
   provide("featherForm", {
     register: (input, validate) => {
@@ -22,13 +28,10 @@ const useForm = () => {
 
       controls = newControls;
     },
-    runValidation: () => {
-      const validation = Object.keys(controls).map((key) => {
-        return controls[key]();
-      });
-      return validation.filter((x) => x.success === false);
-    },
+    runValidation: _validate,
   });
+
+  return { validate: _validate };
 };
 
 export { useForm };

--- a/packages/@featherds/input/src/components/useForm.js
+++ b/packages/@featherds/input/src/components/useForm.js
@@ -1,0 +1,34 @@
+import { provide } from "vue";
+const useForm = () => {
+  let controls = {};
+
+  provide("featherForm", {
+    register: (input, validate) => {
+      controls[input] = validate;
+    },
+    deregister: (input) => {
+      delete controls[input];
+    },
+    reregister: (old, curr) => {
+      const keys = Object.keys(controls);
+      const newControls = keys.reduce((acc, val) => {
+        if (val === old) {
+          acc[curr] = controls[old];
+        } else {
+          acc[val] = controls[val];
+        }
+        return acc;
+      }, {});
+
+      controls = newControls;
+    },
+    runValidation: () => {
+      const validation = Object.keys(controls).map((key) => {
+        return controls[key]();
+      });
+      return validation.filter((x) => x.success === false);
+    },
+  });
+};
+
+export { useForm };

--- a/packages/@featherds/input/src/components/useValidation.js
+++ b/packages/@featherds/input/src/components/useValidation.js
@@ -1,4 +1,4 @@
-import { inject, ref, provide } from "vue";
+import { inject, ref, provide, watch } from "vue";
 const useValidation = (inputId, value, label, schema) => {
   const form = inject("featherForm", false);
   if (schema && form && inputId.value) {
@@ -20,6 +20,13 @@ const useValidation = (inputId, value, label, schema) => {
       }
     };
     form.register(inputId.value, validate);
+    watch(inputId, (curr, old) => {
+      if (curr) {
+        form.reregister(old, curr);
+      } else {
+        form.deregister(old);
+      }
+    });
     return { validate };
   }
   return { validate: () => true };

--- a/packages/@featherds/input/src/components/useValidation.js
+++ b/packages/@featherds/input/src/components/useValidation.js
@@ -1,0 +1,28 @@
+import { inject, ref, provide } from "vue";
+const useValidation = (inputId, value, label, schema) => {
+  const form = inject("featherForm", false);
+  if (schema && form && inputId.value) {
+    const errorMessage = ref("");
+    provide("validationErrorMessage", errorMessage);
+    const validate = () => {
+      try {
+        schema.validateSync(value.value);
+        errorMessage.value = "";
+        return { success: true };
+      } catch (e) {
+        errorMessage.value = e.errors[0];
+        return {
+          success: false,
+          message: e.errors[0],
+          inputId: inputId.value,
+          label: label,
+        };
+      }
+    };
+    form.register(inputId.value, validate);
+    return { validate };
+  }
+  return { validate: () => true };
+};
+
+export { useValidation };

--- a/packages/@featherds/input/src/index.d.ts
+++ b/packages/@featherds/input/src/index.d.ts
@@ -1,5 +1,6 @@
 declare module "@featherds/input" {
   import { defineComponent } from "vue";
   const FeatherInput: ReturnType<typeof defineComponent>;
+  const ValidationHeader: ReturnType<typeof defineComponent>;
   export { FeatherInput };
 }

--- a/packages/@featherds/input/src/index.js
+++ b/packages/@featherds/input/src/index.js
@@ -1,1 +1,2 @@
 export { default as FeatherInput } from "./components/FeatherInput.vue";
+export { default as ValidationHeader } from "./components/ValidationHeader.vue";

--- a/packages/@featherds/menu/src/components/FeatherMenu.vue
+++ b/packages/@featherds/menu/src/components/FeatherMenu.vue
@@ -20,7 +20,7 @@ import { useResize } from "@featherds/composables/events/Resize";
 import { useScroll } from "@featherds/composables/events/Scroll";
 
 export default {
-  emits: ["outside-click", "trigger-click"],
+  emits: ["outside-click", "trigger-click", "close"],
   props: {
     open: {
       type: Boolean,

--- a/packages/@featherds/protected-input/src/components/__snapshots__/FeatherProtectedInput.spec.js.snap
+++ b/packages/@featherds/protected-input/src/components/__snapshots__/FeatherProtectedInput.spec.js.snap
@@ -3,20 +3,20 @@
 exports[`FeatherProtectedInput.vue should change input type when show password is clicked 1`] = `
 <div
   class="feather-input-container"
-  data-v-787e0b58=""
+  data-v-756d6a1a=""
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
-    data-v-787e0b58=""
+    data-v-3828e91d=""
+    data-v-756d6a1a=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         TEST
       </legend>
@@ -24,7 +24,7 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -32,11 +32,11 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -48,7 +48,7 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
         aria-invalid="false"
         class="feather-input"
         data-ref-id="feather-input"
-        data-v-787e0b58=""
+        data-v-756d6a1a=""
         id="feather-input-label"
         maxlength="false"
         name="feather-input-label"
@@ -57,7 +57,7 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -96,8 +96,8 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-787e0b58=""
-    data-v-cef1410a=""
+    data-v-51d97390=""
+    data-v-756d6a1a=""
     id="feather-input-description"
     style="display: none;"
   >
@@ -112,20 +112,20 @@ exports[`FeatherProtectedInput.vue should change input type when show password i
 exports[`FeatherProtectedInput.vue should render with show password icon by default 1`] = `
 <div
   class="feather-input-container"
-  data-v-787e0b58=""
+  data-v-756d6a1a=""
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
-    data-v-787e0b58=""
+    data-v-3828e91d=""
+    data-v-756d6a1a=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         TEST
       </legend>
@@ -133,7 +133,7 @@ exports[`FeatherProtectedInput.vue should render with show password icon by defa
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-input-label"
       style="left: 16px;"
     >
@@ -141,11 +141,11 @@ exports[`FeatherProtectedInput.vue should render with show password icon by defa
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -157,7 +157,7 @@ exports[`FeatherProtectedInput.vue should render with show password icon by defa
         aria-invalid="false"
         class="feather-input"
         data-ref-id="feather-input"
-        data-v-787e0b58=""
+        data-v-756d6a1a=""
         id="feather-input-label"
         maxlength="false"
         name="feather-input-label"
@@ -166,7 +166,7 @@ exports[`FeatherProtectedInput.vue should render with show password icon by defa
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -204,8 +204,8 @@ exports[`FeatherProtectedInput.vue should render with show password icon by defa
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-787e0b58=""
-    data-v-cef1410a=""
+    data-v-51d97390=""
+    data-v-756d6a1a=""
     id="feather-input-description"
     style="display: none;"
   >

--- a/packages/@featherds/radio/src/components/FeatherRadio/FeatherRadio.vue
+++ b/packages/@featherds/radio/src/components/FeatherRadio/FeatherRadio.vue
@@ -4,6 +4,7 @@
       class="feather-radio"
       role="radio"
       ref="input"
+      :id="id"
       :aria-checked="checked ? 'true' : 'false'"
       :aria-disabled="disabled ? 'true' : 'false'"
       :aria-labelledby="labelId"
@@ -54,6 +55,9 @@ export default {
     const focus = () => {
       input.value.focus();
     };
+    const id = computed(() => {
+      return getSafeId("feather-radio-button");
+    });
 
     //register
     const register = inject("register");
@@ -66,6 +70,7 @@ export default {
       disabled: props.disabled,
       value: props.value,
       checked,
+      id,
     };
     register(vm);
     const click = () => {
@@ -80,6 +85,7 @@ export default {
       click,
       input,
       checked,
+      id,
     };
   },
   components: {

--- a/packages/@featherds/radio/src/components/FeatherRadio/__snapshots__/FeatherRadio.spec.js.snap
+++ b/packages/@featherds/radio/src/components/FeatherRadio/__snapshots__/FeatherRadio.spec.js.snap
@@ -10,6 +10,7 @@ exports[`FeatherRadio.vue should set aria-checked based on data 1`] = `
     aria-labelledby="radio-label-id"
     class="feather-radio"
     data-ref-id="feather-radio"
+    id="feather-radio-button"
     role="radio"
     tabindex="0"
   >
@@ -60,6 +61,7 @@ exports[`FeatherRadio.vue should set aria-checked based on data 2`] = `
     aria-labelledby="radio-label-id"
     class="feather-radio"
     data-ref-id="feather-radio"
+    id="feather-radio-button"
     role="radio"
     tabindex="-1"
   >
@@ -110,6 +112,7 @@ exports[`FeatherRadio.vue should set aria-disabled based on property 1`] = `
     aria-labelledby="radio-label-id"
     class="feather-radio"
     data-ref-id="feather-radio"
+    id="feather-radio-button"
     role="radio"
     tabindex="-1"
   >
@@ -159,6 +162,7 @@ exports[`FeatherRadio.vue should set aria-disabled based on property 2`] = `
     aria-labelledby="radio-label-id"
     class="feather-radio"
     data-ref-id="feather-radio"
+    id="feather-radio-button"
     role="radio"
     tabindex="-1"
   >

--- a/packages/@featherds/radio/src/components/FeatherRadioGroup/FeatherRadioGroup.vue
+++ b/packages/@featherds/radio/src/components/FeatherRadioGroup/FeatherRadioGroup.vue
@@ -27,6 +27,7 @@ import {
 } from "@featherds/input-helper";
 import { computed, toRef } from "vue";
 import { useRadioGroup } from "@featherds/composables/radio/RadioGroup";
+
 export default {
   model: {
     prop: "modelValue",
@@ -45,13 +46,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
   },
   setup(props, context) {
     const error = toRef(props, "error");
     const modelValue = toRef(props, "modelValue");
-    const groupId = computed(() => {
-      return getSafeId("feather-radio-group");
-    });
     const descriptionId = computed(() => {
       return getSafeId("feather-input-description");
     });
@@ -69,11 +71,15 @@ export default {
       return _attrs;
     });
 
+    const groupId = computed(() => {
+      return getSafeId("feather-radio-group");
+    });
+
     return {
       groupId,
       descriptionId,
       attrs,
-      ...useRadioGroup(modelValue, context.emit),
+      ...useRadioGroup(modelValue, context.emit, props.label, props.schema),
     };
   },
   components: {

--- a/packages/@featherds/radio/src/components/FeatherRadioGroup/FeatherRadioGroup.vue
+++ b/packages/@featherds/radio/src/components/FeatherRadioGroup/FeatherRadioGroup.vue
@@ -71,12 +71,7 @@ export default {
       return _attrs;
     });
 
-    const groupId = computed(() => {
-      return getSafeId("feather-radio-group");
-    });
-
     return {
-      groupId,
       descriptionId,
       attrs,
       ...useRadioGroup(modelValue, context.emit, props.label, props.schema),

--- a/packages/@featherds/radio/src/components/FeatherRadioGroup/__snapshots__/FeatherRadioGroup.spec.js.snap
+++ b/packages/@featherds/radio/src/components/FeatherRadioGroup/__snapshots__/FeatherRadioGroup.spec.js.snap
@@ -23,7 +23,7 @@ exports[`FeatherRadioGroup.vue should have error text 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
     style=""
   >
@@ -32,7 +32,7 @@ exports[`FeatherRadioGroup.vue should have error text 1`] = `
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       TEST HINT
     </div>
@@ -65,13 +65,13 @@ exports[`FeatherRadioGroup.vue should have hint text 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       TEST HINT
     </div>
@@ -105,7 +105,7 @@ exports[`FeatherRadioGroup.vue should set id and name 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
     style="display: none;"
   >
@@ -140,13 +140,13 @@ exports[`FeatherRadioGroup.vue should stack vertically 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-input-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       TEST HINT
     </div>

--- a/packages/@featherds/select/src/components/FeatherSelect.vue
+++ b/packages/@featherds/select/src/components/FeatherSelect.vue
@@ -98,7 +98,7 @@ export default {
   },
   setup(props) {
     const inputId = computed(() => {
-      return getSafeId("feather-select-label");
+      return getSafeId("feather-select-input");
     });
 
     const { validate } = useValidation(

--- a/packages/@featherds/select/src/components/FeatherSelect.vue
+++ b/packages/@featherds/select/src/components/FeatherSelect.vue
@@ -97,11 +97,7 @@ export default {
     },
   },
   setup(props) {
-    const incomingId = toRef(props, "id");
     const inputId = computed(() => {
-      if (incomingId.value) {
-        return incomingId.value;
-      }
       return getSafeId("feather-select-label");
     });
 

--- a/packages/@featherds/select/src/components/FeatherSelect.vue
+++ b/packages/@featherds/select/src/components/FeatherSelect.vue
@@ -66,6 +66,7 @@ import { FeatherMenu } from "@featherds/menu";
 import { getSafeId } from "@featherds/utils/id";
 import { KEYCODES } from "@featherds/utils/keys";
 import List from "./List";
+import { useValidation } from "@featherds/input/src/components/useValidation";
 
 export default {
   mixins: [InputWrapperMixin, InputSubTextMixin, InputInheritAttrsMixin],
@@ -89,6 +90,29 @@ export default {
         return [];
       },
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
+  },
+  setup(props) {
+    const incomingId = toRef(props, "id");
+    const inputId = computed(() => {
+      if (incomingId.value) {
+        return incomingId.value;
+      }
+      return getSafeId("feather-select-label");
+    });
+    const internalValue = ref(modelValue);
+
+    const { validate } = useValidation(
+      inputId,
+      internalValue,
+      props.label,
+      props.schema
+    );
+
+    return { inputId, internalValue, validate };
   },
   data() {
     return {
@@ -183,6 +207,7 @@ export default {
       }
     },
     handleInputBlur() {
+      this.validate();
       if (this.hasFocus && !this.showMenu) {
         this.hasFocus = false;
       }

--- a/packages/@featherds/select/src/components/FeatherSelect.vue
+++ b/packages/@featherds/select/src/components/FeatherSelect.vue
@@ -108,7 +108,7 @@ export default {
       props.schema
     );
 
-    return { inputId, incomingId, validate };
+    return { inputId, validate };
   },
   data() {
     return {

--- a/packages/@featherds/select/src/components/FeatherSelect.vue
+++ b/packages/@featherds/select/src/components/FeatherSelect.vue
@@ -67,6 +67,7 @@ import { getSafeId } from "@featherds/utils/id";
 import { KEYCODES } from "@featherds/utils/keys";
 import List from "./List";
 import { useValidation } from "@featherds/input/src/components/useValidation";
+import { computed, toRef } from "vue";
 
 export default {
   mixins: [InputWrapperMixin, InputSubTextMixin, InputInheritAttrsMixin],
@@ -103,16 +104,15 @@ export default {
       }
       return getSafeId("feather-select-label");
     });
-    const internalValue = ref(modelValue);
 
     const { validate } = useValidation(
       inputId,
-      internalValue,
+      toRef(props, "modelValue"),
       props.label,
       props.schema
     );
 
-    return { inputId, internalValue, validate };
+    return { inputId, incomingId, validate };
   },
   data() {
     return {
@@ -129,9 +129,6 @@ export default {
     },
     subTextId() {
       return getSafeId("feather-select-description");
-    },
-    inputId() {
-      return getSafeId("feather-select-input");
     },
     inputAttrs() {
       return {

--- a/packages/@featherds/select/src/components/__snapshots__/FeatherSelect.spec.js.snap
+++ b/packages/@featherds/select/src/components/__snapshots__/FeatherSelect.spec.js.snap
@@ -6,21 +6,21 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
 >
   <div
     class="feather-menu feather-select-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
       class="feather-input-wrapper-container feather-select-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -28,7 +28,7 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-select-input"
         style="left: 16px;"
       >
@@ -36,11 +36,11 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
       </label>
       <div
         class="feather-input-wrapper"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -59,7 +59,7 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -84,7 +84,7 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -106,7 +106,7 @@ exports[`FeatherSelect.vue should not raise the label when its empty 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-select-description"
     style="display: none;"
   >
@@ -124,21 +124,21 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
 >
   <div
     class="feather-menu feather-select-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
       class="feather-input-wrapper-container raised feather-select-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -146,7 +146,7 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-select-input"
         style="left: 12px;"
       >
@@ -154,11 +154,11 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
       </label>
       <div
         class="feather-input-wrapper"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -177,7 +177,7 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -202,7 +202,7 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -224,7 +224,7 @@ exports[`FeatherSelect.vue should raise the label when it has a value 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-select-description"
     style="display: none;"
   >
@@ -242,21 +242,21 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
 >
   <div
     class="feather-menu feather-select-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
       class="feather-input-wrapper-container disabled feather-select-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -264,7 +264,7 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-select-input"
         style="left: 16px;"
       >
@@ -272,11 +272,11 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
       </label>
       <div
         class="feather-input-wrapper"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -296,7 +296,7 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <!---->
@@ -321,7 +321,7 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -343,7 +343,7 @@ exports[`FeatherSelect.vue should render in disabled state 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-select-description"
     style="display: none;"
   >
@@ -361,21 +361,21 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
 >
   <div
     class="feather-menu feather-select-menu-container"
-    data-v-6a69cac4=""
+    data-v-0e29b938=""
   >
     
     <div
       class="feather-input-wrapper-container error feather-select-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       menu-trigger=""
     >
       <fieldset
         aria-hidden="true"
         class="feather-input-border"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <legend
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           Users
         </legend>
@@ -383,7 +383,7 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
       <label
         class="feather-input-label"
         data-ref-id="feather-form-element-label"
-        data-v-051667c2=""
+        data-v-3828e91d=""
         for="feather-select-input"
         style="left: 16px;"
       >
@@ -391,11 +391,11 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
       </label>
       <div
         class="feather-input-wrapper"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <div
           class="prefix"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           
           
@@ -414,14 +414,14 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
         
         <div
           class="post"
-          data-v-051667c2=""
+          data-v-3828e91d=""
         >
           <!---->
           <svg
             aria-hidden="true"
             class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-            data-v-051667c2=""
             data-v-0aa06a12=""
+            data-v-3828e91d=""
             data-v-41337cd6=""
             focusable="false"
             role="img"
@@ -467,7 +467,7 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
     
     <div
       class="feather-menu-dropdown bottom-left"
-      data-v-6a69cac4=""
+      data-v-0e29b938=""
       id="feather-menu-dropdown"
       style="display: none;"
     >
@@ -489,7 +489,7 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-select-description"
   >
     <!---->
@@ -497,7 +497,7 @@ exports[`FeatherSelect.vue should render in error state 1`] = `
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       ERROR
     </div>

--- a/packages/@featherds/textarea/src/components/FeatherTextarea.vue
+++ b/packages/@featherds/textarea/src/components/FeatherTextarea.vue
@@ -202,6 +202,7 @@ export default defineComponent({
       this.focused = true;
     },
     handleBlur() {
+      this.validate();
       this.focused = false;
     },
     handleInput(e) {

--- a/packages/@featherds/textarea/src/components/FeatherTextarea.vue
+++ b/packages/@featherds/textarea/src/components/FeatherTextarea.vue
@@ -35,6 +35,8 @@
 <script>
 import { defineComponent } from "vue";
 import { getSafeId } from "@featherds/utils/id";
+import { useValidation } from "@featherds/input/src/components/useValidation";
+import { computed, toRef } from "vue";
 
 import {
   InputWrapper,
@@ -63,6 +65,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    schema: {
+      type: Object,
+      required: false,
+    },
   },
   data() {
     return {
@@ -72,9 +78,6 @@ export default defineComponent({
     };
   },
   computed: {
-    inputId() {
-      return getSafeId("feather-textarea-label");
-    },
     descriptionId() {
       return getSafeId("feather-textarea-description");
     },
@@ -168,6 +171,24 @@ export default defineComponent({
         this.$emit("update:modelValue", v);
       },
     },
+  },
+  setup(props) {
+    const incomingId = toRef(props, "id");
+    const inputId = computed(() => {
+      if (incomingId.value) {
+        return incomingId.value;
+      }
+      return getSafeId("feather-textarea-label");
+    });
+
+    const { validate } = useValidation(
+      inputId,
+      toRef(props, "modelValue"),
+      props.label,
+      props.schema
+    );
+
+    return { inputId, incomingId, validate };
   },
   methods: {
     handleClear() {

--- a/packages/@featherds/textarea/src/components/__snapshots__/FeatherTextarea.spec.js.snap
+++ b/packages/@featherds/textarea/src/components/__snapshots__/FeatherTextarea.spec.js.snap
@@ -6,15 +6,15 @@ exports[`FeatherTextarea.vue should allow custom blur events 1`] = `
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -22,7 +22,7 @@ exports[`FeatherTextarea.vue should allow custom blur events 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -30,11 +30,11 @@ exports[`FeatherTextarea.vue should allow custom blur events 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -53,7 +53,7 @@ exports[`FeatherTextarea.vue should allow custom blur events 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -64,7 +64,7 @@ exports[`FeatherTextarea.vue should allow custom blur events 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -81,15 +81,15 @@ exports[`FeatherTextarea.vue should allow custom focus events 1`] = `
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -97,7 +97,7 @@ exports[`FeatherTextarea.vue should allow custom focus events 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -105,11 +105,11 @@ exports[`FeatherTextarea.vue should allow custom focus events 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -128,7 +128,7 @@ exports[`FeatherTextarea.vue should allow custom focus events 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -139,7 +139,7 @@ exports[`FeatherTextarea.vue should allow custom focus events 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -156,15 +156,15 @@ exports[`FeatherTextarea.vue should clear textarea when clear-icon is clicked 1`
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -172,7 +172,7 @@ exports[`FeatherTextarea.vue should clear textarea when clear-icon is clicked 1`
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 16px;"
     >
@@ -180,11 +180,11 @@ exports[`FeatherTextarea.vue should clear textarea when clear-icon is clicked 1`
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -203,7 +203,7 @@ exports[`FeatherTextarea.vue should clear textarea when clear-icon is clicked 1`
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -214,7 +214,7 @@ exports[`FeatherTextarea.vue should clear textarea when clear-icon is clicked 1`
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -231,15 +231,15 @@ exports[`FeatherTextarea.vue should not render a clear icon when the textarea do
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -247,7 +247,7 @@ exports[`FeatherTextarea.vue should not render a clear icon when the textarea do
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 16px;"
     >
@@ -255,11 +255,11 @@ exports[`FeatherTextarea.vue should not render a clear icon when the textarea do
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -278,7 +278,7 @@ exports[`FeatherTextarea.vue should not render a clear icon when the textarea do
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -289,7 +289,7 @@ exports[`FeatherTextarea.vue should not render a clear icon when the textarea do
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -306,15 +306,15 @@ exports[`FeatherTextarea.vue should render a clear icon when clear has a value a
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -322,7 +322,7 @@ exports[`FeatherTextarea.vue should render a clear icon when clear has a value a
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -330,11 +330,11 @@ exports[`FeatherTextarea.vue should render a clear icon when clear has a value a
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -353,12 +353,12 @@ exports[`FeatherTextarea.vue should render a clear icon when clear has a value a
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <a
           class="action-icon hide-when-disabled"
           data-ref-id="feather-form-element-clear"
-          data-v-051667c2=""
+          data-v-3828e91d=""
           data-v-d1dfbdf8=""
           href="#"
           title="clear"
@@ -386,7 +386,7 @@ exports[`FeatherTextarea.vue should render a clear icon when clear has a value a
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -403,15 +403,15 @@ exports[`FeatherTextarea.vue should render a maxlength attribute and character c
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -419,7 +419,7 @@ exports[`FeatherTextarea.vue should render a maxlength attribute and character c
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -427,11 +427,11 @@ exports[`FeatherTextarea.vue should render a maxlength attribute and character c
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -450,7 +450,7 @@ exports[`FeatherTextarea.vue should render a maxlength attribute and character c
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -461,7 +461,7 @@ exports[`FeatherTextarea.vue should render a maxlength attribute and character c
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -484,15 +484,15 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
 >
   <div
     class="feather-input-wrapper-container error feather-input-content error"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -500,7 +500,7 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 16px;"
     >
@@ -508,11 +508,11 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -531,14 +531,14 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -570,7 +570,7 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -578,7 +578,7 @@ exports[`FeatherTextarea.vue should render an textarea error 1`] = `
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -594,15 +594,15 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
 >
   <div
     class="feather-input-wrapper-container raised error feather-input-content error"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -610,7 +610,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -618,11 +618,11 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -641,14 +641,14 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -680,7 +680,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -688,7 +688,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has a value 1`]
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -704,15 +704,15 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
 >
   <div
     class="feather-input-wrapper-container raised focused error feather-input-content error focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -720,7 +720,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -728,11 +728,11 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -751,14 +751,14 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <svg
           aria-hidden="true"
           class="error-icon hide-when-disabled feather-icon error-icon hide-when-disabled"
-          data-v-051667c2=""
           data-v-0aa06a12=""
+          data-v-3828e91d=""
           data-v-41337cd6=""
           focusable="false"
           role="img"
@@ -790,7 +790,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -798,7 +798,7 @@ exports[`FeatherTextarea.vue should render an textarea error and has focus 1`] =
       aria-live="assertive"
       class="feather-input-error"
       data-ref-id="feather-form-element-error"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       Error text
     </div>
@@ -814,15 +814,15 @@ exports[`FeatherTextarea.vue should render an textarea with a label 1`] = `
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -830,7 +830,7 @@ exports[`FeatherTextarea.vue should render an textarea with a label 1`] = `
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 16px;"
     >
@@ -838,11 +838,11 @@ exports[`FeatherTextarea.vue should render an textarea with a label 1`] = `
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -861,7 +861,7 @@ exports[`FeatherTextarea.vue should render an textarea with a label 1`] = `
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -872,7 +872,7 @@ exports[`FeatherTextarea.vue should render an textarea with a label 1`] = `
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -889,15 +889,15 @@ exports[`FeatherTextarea.vue should render an textarea with a label and hint tex
 >
   <div
     class="feather-input-wrapper-container feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -905,7 +905,7 @@ exports[`FeatherTextarea.vue should render an textarea with a label and hint tex
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 16px;"
     >
@@ -913,11 +913,11 @@ exports[`FeatherTextarea.vue should render an textarea with a label and hint tex
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -936,7 +936,7 @@ exports[`FeatherTextarea.vue should render an textarea with a label and hint tex
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -947,13 +947,13 @@ exports[`FeatherTextarea.vue should render an textarea with a label and hint tex
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       hint text
     </div>
@@ -970,15 +970,15 @@ exports[`FeatherTextarea.vue should render an textarea with a preset value 1`] =
 >
   <div
     class="feather-input-wrapper-container raised feather-input-content"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -986,7 +986,7 @@ exports[`FeatherTextarea.vue should render an textarea with a preset value 1`] =
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -994,11 +994,11 @@ exports[`FeatherTextarea.vue should render an textarea with a preset value 1`] =
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1017,7 +1017,7 @@ exports[`FeatherTextarea.vue should render an textarea with a preset value 1`] =
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1028,13 +1028,13 @@ exports[`FeatherTextarea.vue should render an textarea with a preset value 1`] =
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <div
       class="feather-input-hint"
       data-ref-id="feather-form-element-hint"
-      data-v-cef1410a=""
+      data-v-51d97390=""
     >
       hint text
     </div>
@@ -1051,15 +1051,15 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -1067,7 +1067,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -1075,11 +1075,11 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1098,7 +1098,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1109,7 +1109,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->
@@ -1126,15 +1126,15 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
 >
   <div
     class="feather-input-wrapper-container raised focused feather-input-content focused"
-    data-v-051667c2=""
+    data-v-3828e91d=""
   >
     <fieldset
       aria-hidden="true"
       class="feather-input-border"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <legend
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         label
       </legend>
@@ -1142,7 +1142,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
     <label
       class="feather-input-label"
       data-ref-id="feather-form-element-label"
-      data-v-051667c2=""
+      data-v-3828e91d=""
       for="feather-textarea-label"
       style="left: 12px;"
     >
@@ -1150,11 +1150,11 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
     </label>
     <div
       class="feather-input-wrapper"
-      data-v-051667c2=""
+      data-v-3828e91d=""
     >
       <div
         class="prefix"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         
         
@@ -1173,7 +1173,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
       
       <div
         class="post"
-        data-v-051667c2=""
+        data-v-3828e91d=""
       >
         <!---->
         <!---->
@@ -1184,7 +1184,7 @@ exports[`FeatherTextarea.vue should render an textarea with raised label when fo
   </div>
   <div
     class="feather-input-sub-text"
-    data-v-cef1410a=""
+    data-v-51d97390=""
     id="feather-textarea-description"
   >
     <!---->

--- a/scripts/demoBuild.js
+++ b/scripts/demoBuild.js
@@ -1,6 +1,6 @@
 const build = require("./vite/demoBuild");
 (async () => {
   const prepareDemos = require("./demos");
-  await prepareDemos.run("/demos");
+  await prepareDemos.run();
   await build.run();
 })();

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -5,7 +5,7 @@ const serve = require("./vite/serve");
   const server = await serve.run();
   await server.listen();
 
-  process.env.VUE_DEV_SERVER_URL = `http://localhost.lambdatest.com:${server.config.server.port}`;
+  process.env.VUE_DEV_SERVER_URL = `http://localhost.lambdatest.com:${server.config.server.port}/demos/#`;
 
   const execa = require("execa");
   const wdioBinPath = require.resolve("@wdio/cli/bin/wdio");


### PR DESCRIPTION
- Added examples using `yup`
- Extended validation support across all common form elements
- Tidied up a lot of the test output so it should be fully clean now and work more consistently