### PR TITLE
fix(button): prevent default on disabled btn as anchor tag

### DIFF
--- a/packages/@featherds/button/src/components/FeatherButton.vue
+++ b/packages/@featherds/button/src/components/FeatherButton.vue
@@ -76,6 +76,10 @@ export default {
     data.on = {
       onClick: (e) => {
         if (this.disabled) {
+          if (this.asAnchor) {
+            e.preventDefault();
+          }
+
           this.$emit("disabled-click", e);
         } else {
           this.$emit("click", e);


### PR DESCRIPTION
@click.prevent on the btn does not work on disabled btn as anchor tag. This manually prevents default.

issue: https://github.com/feather-design-system/feather-design-system/issues/57