### PR TITLE
Feature/autocomplete accessibility

### DIFF
--- a/packages/@featherds/autocomplete/demos/Demo.vue
+++ b/packages/@featherds/autocomplete/demos/Demo.vue
@@ -94,7 +94,7 @@ export default defineComponent({
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.results = names
-          .filter((x) => x.toLowerCase().indexOf(q) > -1)
+          .filter((x) => x.toLowerCase().indexOf(q.toLowerCase()) > -1)
           .map((x) => {
             // if (x === "William") {
             //   return {

--- a/packages/@featherds/autocomplete/demos/Demo.vue
+++ b/packages/@featherds/autocomplete/demos/Demo.vue
@@ -4,7 +4,7 @@
       <FeatherAutocomplete
         class="feather-col-6"
         data-ref-id="test"
-        label="Users"
+        label="Select Users"
         v-model="value"
         :loading="loading"
         :results="results"

--- a/packages/@featherds/autocomplete/demos/Disabled.vue
+++ b/packages/@featherds/autocomplete/demos/Disabled.vue
@@ -86,7 +86,7 @@ export default defineComponent({
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.results = names
-          .filter((x) => x.toLowerCase().indexOf(q) > -1)
+          .filter((x) => x.toLowerCase().indexOf(q.toLowerCase()) > -1)
           .map((x) => ({
             _text: x,
           }));

--- a/packages/@featherds/autocomplete/demos/Error.vue
+++ b/packages/@featherds/autocomplete/demos/Error.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.results = names
-          .filter((x) => x.toLowerCase().indexOf(q) > -1)
+          .filter((x) => x.toLowerCase().indexOf(q.toLowerCase()) > -1)
           .map((x) => ({
             _text: x,
           }));

--- a/packages/@featherds/autocomplete/demos/Grid.vue
+++ b/packages/@featherds/autocomplete/demos/Grid.vue
@@ -177,7 +177,7 @@ export default defineComponent({
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.results = people.filter(
-          (x) => x.name.toLowerCase().indexOf(q) > -1
+          (x) => x.name.toLowerCase().indexOf(q.toLowerCase()) > -1
         );
 
         this.loading = false;

--- a/packages/@featherds/autocomplete/demos/SelectionLimit.vue
+++ b/packages/@featherds/autocomplete/demos/SelectionLimit.vue
@@ -86,7 +86,7 @@ export default defineComponent({
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.results = names
-          .filter((x) => x.toLowerCase().indexOf(q) > -1)
+          .filter((x) => x.toLowerCase().indexOf(q.toLowerCase()) > -1)
           .map((x) => ({
             _text: x,
           }));

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
@@ -79,9 +79,17 @@ const baseFunctionality = (type: AutocompleteTypes) => {
       await wrapper.find(".feather-autocomplete-input").trigger("focus");
       expect(getCalls<string>(wrapper, "search")[0][0]).toBe("");
     });
-    it("should perform search with empty string when focused and min char is 0", async () => {
+    it("should not perform search with empty string when focused and min char is 0", async () => {
       const wrapper = getFullWrapper();
       await wrapper.find(".feather-autocomplete-input").trigger("focus");
+      expect(wrapper.emitted("search")).toBeFalsy();
+    });
+    it("should perform search with empty string when focused and space pressed and min char is 0", async () => {
+      const wrapper = getFullWrapper();
+      await wrapper.find(".feather-autocomplete-input").trigger("focus");
+      await wrapper
+        .find(".feather-autocomplete-input")
+        .trigger("keydown.space");
       expect(getCalls<string>(wrapper, "search")[0][0]).toBe("");
     });
     it("should not search when clicked an min char is >0", async () => {

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -35,7 +35,7 @@
             <div
               class="alert"
               role="alert"
-              aria-live="assertive"
+              aria-live="polite"
               aria-atomic="true"
               ref="alert"
             ></div>
@@ -204,6 +204,7 @@ export default defineComponent({
     return {
       typingTimeout: -1 as unknown as TimeoutResult,
       activeChipIndex: -1,
+      activeChipId: "",
     };
   },
   computed: {
@@ -281,9 +282,6 @@ export default defineComponent({
     resultItemId() {
       return getSafeId("result-item");
     },
-    activeChipId() {
-      return getSafeId("active-chip");
-    },
     minCharWarningId() {
       return getSafeId("min-char-warning");
     },
@@ -346,6 +344,7 @@ export default defineComponent({
         input: this.handleTextInput,
         blur: this.handleInputBlur,
         focus: this.handleInputFocus,
+        click: this.handleInputEnter,
         keydown: this.handleInputKeyDown,
       };
     },
@@ -388,6 +387,9 @@ export default defineComponent({
   },
   watch: {
     activeChipIndex(v) {
+      if (v) {
+        this.genActiveChipId();
+      }
       if (v > -1 && this.scrollContainer) {
         this.$nextTick(() => {
           toView(
@@ -470,6 +472,10 @@ export default defineComponent({
     getPre(item: IAutocompleteItemType) {
       return item._pre as IAutocompleteChipIcon;
     },
+    genActiveChipId() {
+      this.activeChipId = getSafeId("active-chip");
+      return this.activeChipId;
+    },
     setAlert(txt: string) {
       const alert = this.$refs.alert as HTMLElement;
       alert.textContent = txt;
@@ -497,9 +503,11 @@ export default defineComponent({
       if (this.modelValue && this.singleSelect) {
         this.inputRef.select();
       }
+    },
+    handleInputEnter() {
+      this.handleInputFocus();
       this.emitSearch();
     },
-
     handleTextInput(e: KeyboardEvent) {
       this.adjustTextArea();
       const target = e.target as HTMLInputElement;
@@ -545,6 +553,17 @@ export default defineComponent({
       if (e.keyCode === KEYCODES.ENTER && this.active.row > -1) {
         e.preventDefault();
         this.selectItem(this.internalResults[this.active.row]);
+        return;
+      }
+      if (
+        (e.keyCode === KEYCODES.ENTER ||
+          e.keyCode === KEYCODES.SPACE ||
+          e.keyCode === KEYCODES.DOWN) &&
+        this.activeChipIndex == -1 &&
+        !this.showMenu
+      ) {
+        e.preventDefault();
+        this.emitSearch();
         return;
       }
 

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -426,7 +426,7 @@ export default defineComponent({
       immediate: true,
     },
     results(v) {
-      if (!this.singleSelect && !this.gridConfig && v && v.length > 0) {
+      if (!this.singleSelect && v && v.length > 0) {
         this.selectFirst();
       }
       this.forceCloseResults = false; // should no longer force close
@@ -619,6 +619,7 @@ export default defineComponent({
         return;
       }
       this.inputRef.focus();
+      this.handleDropdownIconClick();
     },
     handleInputBlur() {
       this.validate();
@@ -660,7 +661,7 @@ export default defineComponent({
         this.forceCloseResults = true;
         return;
       }
-      if (this.forceCloseResults) {
+      if (!this.forceCloseResults) {
         this.emitSearch();
       }
     },

--- a/packages/@featherds/autocomplete/src/components/Results/AutocompleteResults.vue
+++ b/packages/@featherds/autocomplete/src/components/Results/AutocompleteResults.vue
@@ -3,7 +3,6 @@
     class="feather-autocomplete-results-list"
     tabindex="-1"
     aria-hidden="false"
-    aria-live="polite"
     role="listbox"
     :aria-multiselectable="single ? 'false' : 'true'"
     ref="list"

--- a/packages/@featherds/autocomplete/src/components/Results/AutocompleteResultsGrid.vue
+++ b/packages/@featherds/autocomplete/src/components/Results/AutocompleteResultsGrid.vue
@@ -5,7 +5,6 @@
       :class="cls"
       tabindex="-1"
       aria-hidden="false"
-      aria-live="polite"
       role="grid"
       :aria-multiselectable="single ? 'false' : 'true'"
     >

--- a/packages/@featherds/autocomplete/src/components/Results/AutocompleteResultsGrid.vue
+++ b/packages/@featherds/autocomplete/src/components/Results/AutocompleteResultsGrid.vue
@@ -28,6 +28,7 @@
             v-for="(col, colIndex) in config"
             :key="(item[textProp] as string) + col.prop"
             :id="getId(index, colIndex)"
+            :aria-selected="isSelected(item)"
             :class="{ 'focus-cell': isActiveCell(index, colIndex) }"
           >
             <Highlighter

--- a/packages/@featherds/autocomplete/src/components/Results/ResultGrid.ts
+++ b/packages/@featherds/autocomplete/src/components/Results/ResultGrid.ts
@@ -115,8 +115,8 @@ const useResultGrid = (config: IAutocompleteGridColumn[]) => {
     active.col = -1;
   };
   const first = () => {
-    active.row = 0;
-    active.col = 0;
+    reset();
+    moveRowCol(0, 0);
   };
 
   return { reset, handleKeyPress, active, first } as IAutocompleteResultRender;

--- a/packages/@featherds/autocomplete/src/components/Results/__snapshots__/AutocompleteResults.spec.ts.snap
+++ b/packages/@featherds/autocomplete/src/components/Results/__snapshots__/AutocompleteResults.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`Autocomplete Results should mark items as selected that appear in value array 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="true"
   class="feather-autocomplete-results-list"
   role="listbox"
@@ -98,7 +97,6 @@ exports[`Autocomplete Results should mark items as selected that appear in value
 exports[`Autocomplete Results should mark items as selected that appear in value array and active when active index is set. 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="true"
   class="feather-autocomplete-results-list"
   role="listbox"
@@ -194,7 +192,6 @@ exports[`Autocomplete Results should mark items as selected that appear in value
 exports[`Autocomplete Results should support active index being out of range 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="true"
   class="feather-autocomplete-results-list"
   role="listbox"
@@ -289,7 +286,6 @@ exports[`Autocomplete Results should support active index being out of range 1`]
 exports[`Autocomplete Results should support active index within results range 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="true"
   class="feather-autocomplete-results-list"
   role="listbox"
@@ -385,7 +381,6 @@ exports[`Autocomplete Results should support active index within results range 1
 exports[`Autocomplete Results should support no item active 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="true"
   class="feather-autocomplete-results-list"
   role="listbox"
@@ -480,7 +475,6 @@ exports[`Autocomplete Results should support no item active 1`] = `
 exports[`Autocomplete Results should support single select 1`] = `
 <feather-list-stub
   aria-hidden="false"
-  aria-live="polite"
   aria-multiselectable="false"
   class="feather-autocomplete-results-list"
   role="listbox"

--- a/packages/@featherds/autocomplete/src/components/Results/__snapshots__/AutocompleteResultsGrid.spec.ts.snap
+++ b/packages/@featherds/autocomplete/src/components/Results/__snapshots__/AutocompleteResultsGrid.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="true"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -35,6 +34,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -43,6 +43,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -59,6 +60,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -67,6 +69,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -83,6 +86,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -91,6 +95,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -107,6 +112,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -115,6 +121,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -136,7 +143,6 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="true"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -165,6 +171,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class="focus-cell"
           id="ACTIVE"
         >
@@ -173,6 +180,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -189,6 +197,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -197,6 +206,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -213,6 +223,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -221,6 +232,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -237,6 +249,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -245,6 +258,7 @@ exports[`Autocomplete Results Grid should mark items as selected that appear in 
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -266,7 +280,6 @@ exports[`Autocomplete Results Grid should support active index being out of rang
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="true"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -295,6 +308,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -303,6 +317,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -319,6 +334,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -327,6 +343,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -343,6 +360,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -351,6 +369,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -367,6 +386,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -375,6 +395,7 @@ exports[`Autocomplete Results Grid should support active index being out of rang
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -396,7 +417,6 @@ exports[`Autocomplete Results Grid should support active index within results ra
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="true"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -425,6 +445,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
       >
         
         <td
+          aria-selected="true"
           class="focus-cell"
           id="ACTIVE"
         >
@@ -433,6 +454,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -449,6 +471,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -457,6 +480,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -473,6 +497,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -481,6 +506,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -497,6 +523,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -505,6 +532,7 @@ exports[`Autocomplete Results Grid should support active index within results ra
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -526,7 +554,6 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="true"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -555,6 +582,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -563,6 +591,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -579,6 +608,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -587,6 +617,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -603,6 +634,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -611,6 +643,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -627,6 +660,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -635,6 +669,7 @@ exports[`Autocomplete Results Grid should support no item active 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -656,7 +691,6 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
 >
   <table
     aria-hidden="false"
-    aria-live="polite"
     aria-multiselectable="false"
     class="feather-autocomplete-results-grid-container tl1 tr2"
     role="grid"
@@ -685,6 +719,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -693,6 +728,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -709,6 +745,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -717,6 +754,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -733,6 +771,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -741,6 +780,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -757,6 +797,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
       >
         
         <td
+          aria-selected="true"
           class=""
           id=""
         >
@@ -765,6 +806,7 @@ exports[`Autocomplete Results Grid should support single select 1`] = `
           </p>
         </td>
         <td
+          aria-selected="true"
           class=""
           id=""
         >

--- a/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.ts.snap
+++ b/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.ts.snap
@@ -62,7 +62,7 @@ exports[`FeatherAutocomplete base functionality multi disabled state should rend
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -236,7 +236,7 @@ exports[`FeatherAutocomplete base functionality multi disabled state should rend
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -372,7 +372,7 @@ exports[`FeatherAutocomplete base functionality multi should lower label when th
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -508,7 +508,7 @@ exports[`FeatherAutocomplete base functionality multi should not leave previous 
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -573,7 +573,6 @@ exports[`FeatherAutocomplete base functionality multi should not leave previous 
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -749,7 +748,7 @@ exports[`FeatherAutocomplete base functionality multi should raise the label whe
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -963,7 +962,7 @@ exports[`FeatherAutocomplete base functionality multi should show loading spinne
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1028,7 +1027,6 @@ exports[`FeatherAutocomplete base functionality multi should show loading spinne
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -1150,7 +1148,7 @@ exports[`FeatherAutocomplete base functionality multi should show no results tex
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1215,7 +1213,6 @@ exports[`FeatherAutocomplete base functionality multi should show no results tex
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -1341,7 +1338,7 @@ exports[`FeatherAutocomplete base functionality single disabled state should ren
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1495,7 +1492,7 @@ exports[`FeatherAutocomplete base functionality single disabled state should ren
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1631,7 +1628,7 @@ exports[`FeatherAutocomplete base functionality single should lower label when t
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1767,7 +1764,7 @@ exports[`FeatherAutocomplete base functionality single should not leave previous
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -1832,7 +1829,6 @@ exports[`FeatherAutocomplete base functionality single should not leave previous
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="false"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -2007,7 +2003,7 @@ exports[`FeatherAutocomplete base functionality single should raise the label wh
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -2161,7 +2157,7 @@ exports[`FeatherAutocomplete base functionality single should show loading spinn
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -2226,7 +2222,6 @@ exports[`FeatherAutocomplete base functionality single should show loading spinn
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="false"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -2348,7 +2343,7 @@ exports[`FeatherAutocomplete base functionality single should show no results te
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -2413,7 +2408,6 @@ exports[`FeatherAutocomplete base functionality single should show no results te
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="false"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -2541,7 +2535,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should move chip sele
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -2756,7 +2750,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should move chip sele
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -2971,7 +2965,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should not move chip 
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -3186,7 +3180,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should not perform an
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -3400,7 +3394,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should select rightmo
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -3544,7 +3538,6 @@ exports[`FeatherAutocomplete multi:specific chip selection should select rightmo
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -3702,7 +3695,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should select the rig
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -3917,7 +3910,7 @@ exports[`FeatherAutocomplete multi:specific chip selection should should deselec
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -4131,7 +4124,7 @@ exports[`FeatherAutocomplete multi:specific selection limit should clear warning
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -4345,7 +4338,7 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -4488,7 +4481,6 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -4638,7 +4630,7 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           >
@@ -4783,7 +4775,6 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -4933,7 +4924,7 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           >
@@ -5000,7 +4991,6 @@ exports[`FeatherAutocomplete multi:specific selection limit should display a war
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="true"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -5206,7 +5196,7 @@ exports[`FeatherAutocomplete multi:specific should hide/reset menu and clear tex
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -5342,7 +5332,7 @@ exports[`FeatherAutocomplete single:specific should close menu when enter is pre
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -5407,7 +5397,6 @@ exports[`FeatherAutocomplete single:specific should close menu when enter is pre
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="false"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"
@@ -5563,7 +5552,7 @@ exports[`FeatherAutocomplete single:specific should handle a null property on va
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -5717,7 +5706,7 @@ exports[`FeatherAutocomplete single:specific should show add new element when in
         >
           <div
             aria-atomic="true"
-            aria-live="assertive"
+            aria-live="polite"
             class="alert"
             role="alert"
           />
@@ -5782,7 +5771,6 @@ exports[`FeatherAutocomplete single:specific should show add new element when in
         <ul
           aria-hidden="false"
           aria-label="Users"
-          aria-live="polite"
           aria-multiselectable="false"
           class="feather-list feather-autocomplete-results-list autocomplete-results"
           id="feather-autocomplete-input-results"


### PR DESCRIPTION
Attempting to improve screen reader text in the autocomplete control, there were a number of deficiencies in how it was read out that made it tricky to evaluate.

I have;

- Changed the default behaviour to require a separate discrete button press to open the dropdown, so that the actual control values can be read out. The click behaviour should be as before
- Updated the ARIA values so that the values are more understandable and read out reliably
- Tweaked the grid scenario so it actually calls out when selected and auto selects the first entry properly
- Updated the demos to be case insensitive