### PR TITLE
fix(app-layout): addresses #152 - SkipToContent link changes routes

### DIFF
--- a/packages/@featherds/app-layout/src/components/SkipContentLink.spec.ts
+++ b/packages/@featherds/app-layout/src/components/SkipContentLink.spec.ts
@@ -1,0 +1,31 @@
+import { mount } from "@vue/test-utils";
+import SkipContentLink from "./SkipContentLink.vue";
+let scrollIntoViewMock = jest.fn();
+window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+const getWrapper = () =>
+  mount(SkipContentLink, {
+    props: {
+      content: "test",
+      skipLabel: "This is a text passage",
+    },
+    attachTo: "body",
+  });
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="test"></div>
+  `;
+});
+describe("SkipContentLink", () => {
+  it("should match snapshot", () => {
+    const wrapper = getWrapper();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it("should use smooth scroll", () => {
+    const wrapper = getWrapper();
+    wrapper.trigger("click");
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(document.activeElement?.id).toBe("test");
+  });
+});

--- a/packages/@featherds/app-layout/src/components/SkipContentLink.vue
+++ b/packages/@featherds/app-layout/src/components/SkipContentLink.vue
@@ -23,16 +23,12 @@ export default defineComponent({
   },
   methods: {
     scrollTo(e: MouseEvent) {
-      if (!(this as any).$router) {
-        return;
-      } else {
-        e.preventDefault();
-        const scrollEl = document.getElementById(this.content);
-        if (scrollEl) {
-          scrollEl.scrollIntoView({ behavior: "smooth" });
-          scrollEl.tabIndex = -1;
-          scrollEl.focus();
-        }
+      e.preventDefault();
+      const scrollEl = document.getElementById(this.content);
+      if (scrollEl) {
+        scrollEl.scrollIntoView({ behavior: "smooth" });
+        scrollEl.tabIndex = -1;
+        scrollEl.focus();
       }
     },
   },
@@ -42,6 +38,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import "@featherds/styles/mixins/elevation";
 @import "@featherds/styles/mixins/typography";
+
 a.skip {
   width: 1px;
   height: 1px;
@@ -55,6 +52,7 @@ a.skip {
   top: 0px;
   left: 0px;
   border: 1px solid var($primary);
+
   &:focus {
     width: auto;
     height: auto;

--- a/packages/@featherds/app-layout/src/components/__snapshots__/SkipContentLink.spec.ts.snap
+++ b/packages/@featherds/app-layout/src/components/__snapshots__/SkipContentLink.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SkipContentLink should match snapshot 1`] = `
+<a
+  class="skip"
+  href="#test"
+>
+  This is a text passage
+</a>
+`;


### PR DESCRIPTION
Closes #152 - Changing the original fix to simply always use the JS smoothscroll approach rather than trying to be fancy and sniff the router. The accessibility impact is minimal and the behaviour will now be consistent.