### PR TITLE
Feature/feather 680 - autocomplete single select fires 2 update:modelValue events.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,18 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Chrome Debug Feather Demo",
+      "url": "http://localhost:3000"
+    },
+    {
+      "type": "msedge",
+      "request": "launch",
+      "name": "Edge Debug Feather Demo",
+      "url": "http://localhost:3000"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Current Test File",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19985,7 +19985,7 @@
       }
     },
     "packages/@featherds/app-bar": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/app-layout": "file:../app-layout",
@@ -19998,7 +19998,7 @@
       }
     },
     "packages/@featherds/app-layout": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20007,7 +20007,7 @@
       }
     },
     "packages/@featherds/app-rail": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/app-layout": "file:../app-layout",
@@ -20020,7 +20020,7 @@
       }
     },
     "packages/@featherds/autocomplete": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/chips": "file:../chips",
@@ -20035,7 +20035,7 @@
       }
     },
     "packages/@featherds/back-button": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/icon": "file:../icon",
@@ -20046,7 +20046,7 @@
       }
     },
     "packages/@featherds/badge": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/styles": "file:../styles",
@@ -20054,7 +20054,7 @@
       }
     },
     "packages/@featherds/button": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/ripple": "file:../ripple",
@@ -20063,7 +20063,7 @@
       }
     },
     "packages/@featherds/card": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/ripple": "file:../ripple",
@@ -20072,7 +20072,7 @@
       }
     },
     "packages/@featherds/checkbox": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/input-helper": "file:../input-helper",
@@ -20082,7 +20082,7 @@
       }
     },
     "packages/@featherds/chips": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20094,14 +20094,14 @@
       }
     },
     "packages/@featherds/composables": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "dependencies": {
         "@featherds/utils": "file:../utils",
         "vue": "^3.1.0-0"
       }
     },
     "packages/@featherds/date-input": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/button": "file:../button",
@@ -20117,7 +20117,7 @@
       }
     },
     "packages/@featherds/dialog": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20128,7 +20128,7 @@
       }
     },
     "packages/@featherds/drawer": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20140,7 +20140,7 @@
       }
     },
     "packages/@featherds/dropdown": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/list": "file:../list",
@@ -20150,7 +20150,7 @@
       }
     },
     "packages/@featherds/expansion": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/icon": "file:../icon",
@@ -20160,7 +20160,7 @@
       }
     },
     "packages/@featherds/footer": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/icon": "file:../icon",
@@ -20169,14 +20169,14 @@
       }
     },
     "packages/@featherds/icon": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "vue": "^3.1.0-0"
       }
     },
     "packages/@featherds/input": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/icon": "file:../icon",
@@ -20188,7 +20188,7 @@
       }
     },
     "packages/@featherds/input-helper": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/styles": "file:../styles",
@@ -20196,7 +20196,7 @@
       }
     },
     "packages/@featherds/list": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/ripple": "file:../ripple",
@@ -20207,7 +20207,7 @@
       }
     },
     "packages/@featherds/megamenu": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/dialog": "file:../dialog",
@@ -20218,7 +20218,7 @@
       }
     },
     "packages/@featherds/menu": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20229,7 +20229,7 @@
       }
     },
     "packages/@featherds/navigation-rail": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20241,7 +20241,7 @@
       }
     },
     "packages/@featherds/pagination": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/button": "file:../button",
@@ -20252,7 +20252,7 @@
       }
     },
     "packages/@featherds/pdf-viewer": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/button": "file:../button",
@@ -20265,7 +20265,7 @@
       }
     },
     "packages/@featherds/popover": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20275,7 +20275,7 @@
       }
     },
     "packages/@featherds/progress": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/styles": "file:../styles",
@@ -20283,7 +20283,7 @@
       }
     },
     "packages/@featherds/protected-input": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20293,7 +20293,7 @@
       }
     },
     "packages/@featherds/radio": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20304,14 +20304,14 @@
       }
     },
     "packages/@featherds/ripple": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "vue": "^3.1.0-0"
       }
     },
     "packages/@featherds/select": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/icon": "file:../icon",
@@ -20324,7 +20324,7 @@
       }
     },
     "packages/@featherds/snackbar": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/styles": "file:../styles",
@@ -20332,11 +20332,11 @@
       }
     },
     "packages/@featherds/styles": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "UNLICENSED"
     },
     "packages/@featherds/switch": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/styles": "file:../styles",
@@ -20344,7 +20344,7 @@
       }
     },
     "packages/@featherds/table": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "UNLICENSED",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20355,7 +20355,7 @@
       }
     },
     "packages/@featherds/tabs": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20365,7 +20365,7 @@
       }
     },
     "packages/@featherds/textarea": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/input-helper": "file:../input-helper",
@@ -20375,7 +20375,7 @@
       }
     },
     "packages/@featherds/tooltip": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/composables": "file:../composables",
@@ -20386,10 +20386,10 @@
       }
     },
     "packages/@featherds/utils": {
-      "version": "0.12.15"
+      "version": "0.12.16"
     },
     "packages/@featherds/vuepress-theme-featherds": {
-      "version": "0.12.15",
+      "version": "0.12.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@featherds/app-bar": "file:../app-bar",

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
@@ -893,6 +893,36 @@ describe("FeatherAutocomplete", () => {
         getCalls<[IAutocompleteItemType[]]>(wrapper, "update:modelValue")[0][0]
       ).toStrictEqual(results[index]);
     });
+    it("should fire single update:modelValue when clicked", async () => {
+      const results = getResults();
+      const wrapper = getFullWrapper();
+      await wrapper
+        .find<HTMLInputElement>(".feather-autocomplete-input")
+        .trigger("focus");
+
+      await wrapper.setProps({
+        results,
+      });
+
+      // search
+      const query = "item";
+      wrapper.vm.query = query;
+
+      // click the 2nd result
+      await wrapper
+        .findComponent({ ref: "results" })
+        .findAll(".result-item")[1]
+        .trigger("click");
+
+      await wrapper.find(".feather-autocomplete-input").trigger("blur");
+      await wrapper.vm.$nextTick();
+      const events = getCalls<[IAutocompleteItemType[]]>(
+        wrapper,
+        "update:modelValue"
+      );
+
+      expect(events.length).toBe(1);
+    });
     it("should display the current selected value if no new selection is made", async () => {
       vi.useFakeTimers({
         toFake: ["setTimeout", "clearTimeout"],

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -626,19 +626,7 @@ export default defineComponent({
     handleInputBlur(e: FocusEvent) {
       this.validate();
 
-      if (!!(this.singleSelect && e.relatedTarget)) {
-        const clickedLI = (e.relatedTarget as HTMLElement).classList.contains(
-          "feather-list-item"
-        );
-
-        if (!clickedLI) {
-          console.log("BLUR");
-          this.strategy.handleInputBlur(); // MUST DO THIS FOR KEYBOARD
-        }
-      } else {
-        this.strategy.handleInputBlur();
-      }
-
+      this.strategy.handleInputBlur(e);
       if (this.forceCloseResults || !this.showMenu) {
         this.handleOutsideClick();
       }
@@ -653,8 +641,6 @@ export default defineComponent({
       this.adjustTextArea();
     },
     clickedItem(item: IAutocompleteItemType) {
-      console.log("item", item);
-
       this.selectItem(item);
       //clear everything and re focus
       this.internalResults = [];

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -623,9 +623,22 @@ export default defineComponent({
       this.inputRef.focus();
       this.handleDropdownIconClick();
     },
-    handleInputBlur() {
+    handleInputBlur(e: FocusEvent) {
       this.validate();
-      this.strategy.handleInputBlur();
+
+      if (!!(this.singleSelect && e.relatedTarget)) {
+        const clickedLI = (e.relatedTarget as HTMLElement).classList.contains(
+          "feather-list-item"
+        );
+
+        if (!clickedLI) {
+          console.log("BLUR");
+          this.strategy.handleInputBlur(); // MUST DO THIS FOR KEYBOARD
+        }
+      } else {
+        this.strategy.handleInputBlur();
+      }
+
       if (this.forceCloseResults || !this.showMenu) {
         this.handleOutsideClick();
       }
@@ -640,6 +653,8 @@ export default defineComponent({
       this.adjustTextArea();
     },
     clickedItem(item: IAutocompleteItemType) {
+      console.log("item", item);
+
       this.selectItem(item);
       //clear everything and re focus
       this.internalResults = [];

--- a/packages/@featherds/autocomplete/src/components/Strategies.ts
+++ b/packages/@featherds/autocomplete/src/components/Strategies.ts
@@ -103,12 +103,20 @@ const useStrategy = (
     clickedItem() {
       component.forceCloseResults.value = true;
     },
-    handleInputBlur() {
+    handleInputBlur(e: FocusEvent) {
+      const userClickedLI = !!(
+        e.relatedTarget &&
+        (e.relatedTarget as HTMLElement).classList.contains("feather-list-item")
+      );
+
       //select active index
       if (resultsRender.active.row > -1) {
         const item = component.internalResults.value[resultsRender.active.row];
         if (item && item._new && component.allowNew) {
           emit("new", item._new as string);
+        } else if (type === "single" && userClickedLI) {
+          // user clicked with mouse; prevent selection on blur
+          e.preventDefault();
         } else {
           emit("update:modelValue", item);
         }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import vue from "@vitejs/plugin-vue";
 import { sassImports, moduleImport, fileImport } from "./scripts/vite/alias.js";
 // https://vitejs.dev/config/


### PR DESCRIPTION
Addresses #175.

## Summary:  
When navigating via keyboard, the onblur event sets the selected item.  When using the mouse to select from the list, this onblur event fires first (1st update:modelValue) and the click event fires the 2nd update:modelValue.  Solution was to prevent default blur behavior when the event.relatedTarget is an item in the list.