### PR TITLE
docs: npm package name to lowercase

### DIFF
--- a/docs/Components/AppBar/README.md
+++ b/docs/Components/AppBar/README.md
@@ -1,6 +1,7 @@
 ---
 title: "App Bar"
-pre: "@featherds/app-bar"
+pre: ""
+npm: "@featherds/app-bar"
 description: "A header component that is anchored to the top of the application window and provides screen-specific information and actions to the user."
 lang: en-US
 tags: ["AppBar", "App-Bar", "component"]

--- a/docs/Components/AppLayout/README.md
+++ b/docs/Components/AppLayout/README.md
@@ -1,6 +1,7 @@
 ---
 title: "App Layout"
-pre: "@featherds/app-layout"
+pre: ""
+npm: "@featherds/app-layout"
 description: "Provides common application layouts to quickly get started."
 lang: en-US
 tags: ["AppLayout", "App-Layout", "component"]

--- a/docs/Components/AppRail/README.md
+++ b/docs/Components/AppRail/README.md
@@ -1,6 +1,7 @@
 ---
 title: "App Rail"
-pre: "@featherds/app-Rail"
+pre: ""
+npm: "@featherds/app-rail"
 description: "The App Rail provides users with persistent access to the top level of application navigation."
 lang: en-US
 tags: ["AppRail", "component"]

--- a/docs/Components/Autocomplete/README.md
+++ b/docs/Components/Autocomplete/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Autocomplete"
-pre: "@featherds/autocomplete"
+pre: ""
+npm: "@featherds/autocomplete"
 description: "Helps users to search for, select and provide valid answers from large datasets."
 lang: en-US
 tags: ["Autocomplete", "component"]

--- a/docs/Components/BackButton/README.md
+++ b/docs/Components/BackButton/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Back Button"
-pre: "@featherds/back-button"
+pre: ""
+npm: "@featherds/back-button"
 description: "A generic button that allows the user to go back to a previous page."
 lang: en-US
 tags: ["BackButton", "Back-Button", "component"]

--- a/docs/Components/Badge/README.md
+++ b/docs/Components/Badge/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Badge"
-pre: "@featherds/badge"
+pre: ""
+npm: "@featherds/badge"
 description: "Badges are small status descriptors for UI elements."
 lang: en-US
 tags: ["Badge", "component"]

--- a/docs/Components/Button/README.md
+++ b/docs/Components/Button/README.md
@@ -1,7 +1,8 @@
 ---
 title: "Button"
 lang: en-US
-pre: "@featherds/button"
+pre: ""
+npm: "@featherds/button"
 description: "An interaction point to help users initiate actions or navigate through your application."
 tags: ["Button", "component"]
 menu: components

--- a/docs/Components/Card/README.md
+++ b/docs/Components/Card/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Card"
-pre: "@featherds/card"
+pre: ""
+npm: "@featherds/card"
 description: "Cards are self-contained UI regions that provide a high-level summary of a single topic."
 lang: en-US
 tags: ["Card", "component"]

--- a/docs/Components/Checkbox/README.md
+++ b/docs/Components/Checkbox/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Checkbox"
-pre: "@featherds/checkbox"
+pre: ""
+npm: "@featherds/checkbox"
 description: "Allows users to select one or many options."
 lang: en-US
 tags: ["Checkbox", "component"]

--- a/docs/Components/Chips/README.md
+++ b/docs/Components/Chips/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Chips"
-pre: "@featherds/chips"
+pre: ""
+npm: "@featherds/chips"
 description: "Chips are delicious."
 lang: en-US
 tags: ["FeatherChip", "component"]

--- a/docs/Components/DateInput/README.md
+++ b/docs/Components/DateInput/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Date Input"
-pre: "@featherds/date-input"
+pre: ""
+npm: "@featherds/date-input"
 description: "Allows users to select a date from the past, present or future."
 lang: en-US
 tags: ["DateInput", "component"]

--- a/docs/Components/Dialog/README.md
+++ b/docs/Components/Dialog/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Dialog"
-pre: "@featherds/dialog"
+pre: ""
+npm: "@featherds/dialog"
 description: "Provides easy access to important information and/or limits focus to the interaction required for a user to complete a given task."
 lang: en-US
 tags: ["Dialog", "component"]

--- a/docs/Components/Drawer/README.md
+++ b/docs/Components/Drawer/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Drawer"
-pre: "@featherds/drawer"
+pre: ""
+npm: "@featherds/drawer"
 description: "Used to provide relevant information or simple tasks on top of one or more pages in an application."
 lang: en-US
 tags: ["Drawer", "component"]

--- a/docs/Components/Dropdown/README.md
+++ b/docs/Components/Dropdown/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Dropdown"
-pre: "@featherds/dropdown"
+pre: ""
+npm: "@featherds/dropdown"
 description: "A small container for menus and options."
 lang: en-US
 tags: ["Dropdown", "component"]

--- a/docs/Components/Elevation/README.md
+++ b/docs/Components/Elevation/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Elevation"
-pre: "@featherds/styles"
+pre: "NOT USED"
+npm: "@featherds/styles"
 description: "Helps define heirarchy through a sense of depth."
 lang: en-US
 tags: ["Elevation", "component"]

--- a/docs/Components/Expansion/README.md
+++ b/docs/Components/Expansion/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Expansion"
-pre: "@featherds/expansion"
+pre: ""
+npm: "@featherds/expansion"
 description: "An expansion panel is a lightweight container that may either stand alone or be connected to a larger surface, such as a card."
 lang: en-US
 tags: ["Expansion", "component"]

--- a/docs/Components/Footer/README.md
+++ b/docs/Components/Footer/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Footer"
-pre: "@featherds/footer"
+pre: ""
+npm: "@featherds/footer"
 description: "Provides important links, licensing details and copyright information."
 lang: en-US
 tags: ["Footer", "component"]

--- a/docs/Components/Grid/README.md
+++ b/docs/Components/Grid/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Grid"
-pre: "@featherds/styles"
+pre: ""
+npm: "@featherds/styles"
 description: "Tools and presets for scaffolding your application layout."
 lang: en-US
 tags: ["Grid", "component"]

--- a/docs/Components/Icon/README.md
+++ b/docs/Components/Icon/README.md
@@ -1,8 +1,9 @@
 ---
 title: "Icon"
-lang: en-US
-pre: "@featherds/icon"
+pre: ""
+npm: "@featherds/icon"
 description: "Rich iconography to help make your content engage and inspire."
+lang: en-US
 tags: ["Icon", "component"]
 menu: components
 ---

--- a/docs/Components/Input/README.md
+++ b/docs/Components/Input/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Input"
-pre: "@featherds/input"
+pre: ""
+npm: "@featherds/input"
 description: "Allows users to enter and edit text."
 lang: en-US
 tags: ["Input", "component"]

--- a/docs/Components/List/README.md
+++ b/docs/Components/List/README.md
@@ -1,6 +1,7 @@
 ---
 title: "List"
-pre: "@featherds/list"
+pre: ""
+npm: "@featherds/list"
 description: "Lists are convenient ways to group data elements."
 lang: en-US
 tags: ["List", "component"]

--- a/docs/Components/Megamenu/README.md
+++ b/docs/Components/Megamenu/README.md
@@ -1,8 +1,9 @@
 ---
 title: "Megamenu"
-lang: en-US
-pre: "@featherds/megamenu"
+pre: ""
+npm: "@featherds/megamenu"
 description: "An enhanced dropdown type menu but for more complex content."
+lang: en-US
 tags: ["Megamenu", "component"]
 menu: components
 ---

--- a/docs/Components/NavigationRail/README.md
+++ b/docs/Components/NavigationRail/README.md
@@ -1,8 +1,9 @@
 ---
 title: "Navigation Rail"
-pre: "@featherds/navigation-rail"
-lang: en-US
+pre: ""
+npm: "@featherds/navigation-rail"
 description: "A side rail for holding navigation elements and related information."
+lang: en-US
 tags: ["NavigationRail", "component"]
 menu: components
 ---

--- a/docs/Components/Pagination/README.md
+++ b/docs/Components/Pagination/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Pagination"
-pre: "@featherds/pagination"
+pre: ""
+npm: "@featherds/pagination"
 description: "Pagination elements display information about the number of pages that exist of a list of items and provide controls to navigate through them."
 lang: en-US
 tags: ["Pagination", "component"]

--- a/docs/Components/PdfViewer/README.md
+++ b/docs/Components/PdfViewer/README.md
@@ -1,6 +1,7 @@
 ---
 title: "PDF Viewer"
-pre: "@featherds/pdf-viewer"
+pre: ""
+npm: "@featherds/pdf-viewer"
 description: "Designed to view documents within the existing context and provide access to controls."
 lang: en-US
 tags: ["PdfViewer", "component"]

--- a/docs/Components/Popover/README.md
+++ b/docs/Components/Popover/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Popover"
-pre: "@featherds/popover"
+pre: ""
+npm: "@featherds/popover"
 description: "Popovers are overlays that contain detailed content that is triggered by the user by clicking on its associated element."
 lang: en-US
 tags: ["Popover", "component"]

--- a/docs/Components/Progress/README.md
+++ b/docs/Components/Progress/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Progress"
-pre: "@featherds/progress"
+pre: ""
+npm: "@featherds/progress"
 description: "Intended to visualise progress or state of an application."
 lang: en-US
 tags: ["Progress", "component"]

--- a/docs/Components/ProtectedInput/README.md
+++ b/docs/Components/ProtectedInput/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Protected Input"
-pre: "@featherds/protected-input"
+pre: ""
+npm: "@featherds/protected-input"
 design: "A variation of the standard text input field but used for discreet and confidential information."
 lang: en-US
 tags: ["ProtectedInput", "component"]

--- a/docs/Components/Radio/README.md
+++ b/docs/Components/Radio/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Radio"
-pre: "@featherds/radio"
+pre: ""
+npm: "@featherds/radio"
 description: "Enables a user to choose one option from a group of options."
 lang: en-US
 tags: ["Radio", "component"]

--- a/docs/Components/Ripple/README.md
+++ b/docs/Components/Ripple/README.md
@@ -1,8 +1,9 @@
 ---
 title: "Ripple"
-lang: en-US
 pre: "@featherds/ripple"
+npm: ""
 description: "Provides feedback on clickable elements that is both useful and beautiful."
+lang: en-US
 tags: ["Ripple", "component"]
 menu: components
 ---

--- a/docs/Components/Select/README.md
+++ b/docs/Components/Select/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Select"
-pre: "@featherds/select"
+pre: ""
+npm: "@featherds/select"
 description: "A dropdown list control that presents the user with a list of options allowing them to select a single option from the menu. "
 lang: en-US
 tags: ["Select", "component"]

--- a/docs/Components/Snackbar/README.md
+++ b/docs/Components/Snackbar/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Snackbar"
-pre: "@featherds/snackbar"
+pre: ""
+npm: "@featherds/snackbar"
 description: "A small, self-dismissing message container for displaying transient information that does not require user interaction."
 lang: en-US
 tags: ["Snackbar", "component"]

--- a/docs/Components/Table/README.md
+++ b/docs/Components/Table/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Table"
-pre: "@featherds/table"
+pre: ""
+npm: "@featherds/table"
 description: "Tables display a matrix of data with functionality to assist in sorting and filtering of information."
 lang: en-US
 tags: ["Table", "component"]

--- a/docs/Components/Tabs/README.md
+++ b/docs/Components/Tabs/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Tabs"
-pre: "@featherds/tabs"
+pre: ""
+npm: "@featherds/tabs"
 description: "Used to organize content and allow users to toggle between different page views and content within the same page."
 lang: en-US
 tags: ["Tabs", "component"]

--- a/docs/Components/Textarea/README.md
+++ b/docs/Components/Textarea/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Textarea"
-pre: "@featherds/textarea"
+pre: ""
+npm: "@featherds/textarea"
 description: "Provides users with a suitable field size to accommodate more than a single line of text."
 lang: en-US
 tags: ["Textarea", "component"]

--- a/docs/Components/ToggleButton/README.md
+++ b/docs/Components/ToggleButton/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Toggle Button"
-pre: "@featherds/toggle-button"
+pre: ""
+npm: "@featherds/toggle-button"
 description: "Allow users to choose one option from a set of mutually exclusive options."
 lang: en-US
 tags: ["Togglebutton", "component"]

--- a/docs/Components/Tooltip/README.md
+++ b/docs/Components/Tooltip/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Tooltip"
-pre: "@featherds/tooltip"
+pre: ""
+npm: "@featherds/tooltip"
 description: "A small content box triggered by hovering or focusing over a certain area."
 lang: en-US
 tags: ["Tooltip", "component"]

--- a/docs/Components/Utils/README.md
+++ b/docs/Components/Utils/README.md
@@ -1,8 +1,9 @@
 ---
 title: "Utils"
-lang: en-US
 pre: "@featherds/utils"
+npm: ""
 description: "Handy utilities for common use cases."
+lang: en-US
 tags: ["Utils", "component"]
 menu: components
 ---

--- a/docs/Foundation/Styles/Color/README.md
+++ b/docs/Foundation/Styles/Color/README.md
@@ -2,6 +2,7 @@
 title: "Color"
 lang: en-US
 pre: "styles"
+npm: ""
 description: "Used to establish tone, identity and impact in a beautiful and accessible manner."
 tags: ["Foundation", "Color"]
 menu: foundation

--- a/docs/Foundation/Styles/Elevation/README.md
+++ b/docs/Foundation/Styles/Elevation/README.md
@@ -2,6 +2,7 @@
 title: "Elevation"
 lang: en-US
 pre: "styles"
+npm: ""
 description: "Used to define the distance between any two elements on the z-axis."
 tags: ["Foundation", "Elevation"]
 menu: foundation
@@ -27,7 +28,7 @@ Elevation is simulated by the generation of a drop-shadow on component surfaces.
 
 ### Elevations in Dark Mode
 
-Elevation in dark most is calculated differently due to the low contrast of a drop shadow against a dark gray or black background used in dark mode. The surfaces inherit both the application primary color as well as a tint that is meant to emulate the surface of the component interacting with the light being cast onto it. These surface values may be generated procedurally or may be hard-coded depending on your needs.
+Elevation in dark mode is calculated differently due to the low contrast of a drop shadow against a dark gray or black background used in dark mode. The surfaces inherit both the application primary color as well as a tint that is meant to emulate the surface of the component interacting with the light being cast onto it. These surface values may be generated procedurally or may be hard-coded depending on your needs.
 
 <ClientOnly>
 <picture>

--- a/docs/Foundation/Styles/Typography/README.md
+++ b/docs/Foundation/Styles/Typography/README.md
@@ -2,6 +2,7 @@
 title: "Typography"
 lang: en-US
 pre: "styles"
+npm: ""
 description: "Used to define information hierarchy"
 tags: ["Foundation", "Typography"]
 menu: foundation

--- a/docs/Guides/FormValidation/README.md
+++ b/docs/Guides/FormValidation/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Form Validation"
-pre: "@featherds/input"
+pre: ""
+npm: "@featherds/input"
 description: "Guidance and support for effective forms."
 lang: en-US
 tags: ["validation", "guide"]

--- a/docs/Guides/Themes/README.md
+++ b/docs/Guides/Themes/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Themes"
-pre: "@featherds/styles"
+pre: ""
+npm: "@featherds/styles"
 description: "How to use themes to style your application"
 lang: en-US
 tags: ["Themes", "guide"]

--- a/docs/Guides/Typography/README.md
+++ b/docs/Guides/Typography/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Typography"
-pre: "@featherds/styles"
+pre: ""
+npm: "@featherds/styles"
 description: "Rich type and powerful messaging."
 lang: en-US
 tags: ["Typography", "guide"]

--- a/docs/Guides/Variables/README.md
+++ b/docs/Guides/Variables/README.md
@@ -1,6 +1,7 @@
 ---
 title: "Variables"
-pre: "@featherds/styles"
+pre: ""
+npm: "@featherds/styles"
 description: "Powerful theming and customisation."
 lang: en-US
 tags: ["Variables", "guide"]

--- a/packages/@featherds/vuepress-theme-featherds/lib/layouts/Layout.vue
+++ b/packages/@featherds/vuepress-theme-featherds/lib/layouts/Layout.vue
@@ -7,6 +7,7 @@
       <div class="title-section center feather-container">
         <div class="content-container">
           <p class="pre-text">{{ preText }}</p>
+          <p class="npm-name">{{ npmName }}</p>
           <h1 class="title" :id="idSafeTitle">
             <a
               class="header-anchor"
@@ -80,6 +81,9 @@ export default {
     preText() {
       return this.$page.frontmatter.pre;
     },
+    npmName() {
+      return this.$page.frontmatter.npm;
+    },
     menu() {
       return this.$page.frontmatter.menu;
     },
@@ -146,11 +150,16 @@ $contentWidth: 47.5rem;
   margin-bottom: 2.5rem;
   padding: 2.5rem 0;
   background: var($background);
-  .pre-text {
+  .pre-text,
+  .npm-name {
     @include overline();
     color: var($primary);
     margin: 0;
     margin-bottom: 0.5rem;
+  }
+
+  .npm-name {
+    text-transform: lowercase;
   }
   .title-description {
     margin: 0;


### PR DESCRIPTION
npm package name on component pages appearing in uppercase was confusing to end users.