### PR TITLE
fix(autocomplete): default active row initial load (#186)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@vuepress/plugin-google-analytics": "2.0.0-beta.59",
         "@vuepress/plugin-register-components": "2.0.0-beta.59",
         "@wdio/cli": "^8.15.10",
+        "@wdio/globals": "^8.15.10",
         "@wdio/local-runner": "^8.15.10",
         "@wdio/mocha-framework": "^8.15.10",
         "@wdio/selenium-standalone-service": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@vuepress/plugin-google-analytics": "2.0.0-beta.59",
     "@vuepress/plugin-register-components": "2.0.0-beta.59",
     "@wdio/cli": "^8.15.10",
+    "@wdio/globals": "^8.15.10",
     "@wdio/local-runner": "^8.15.10",
     "@wdio/mocha-framework": "^8.15.10",
     "@wdio/selenium-standalone-service": "^8.15.0",

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.spec.ts
@@ -886,6 +886,7 @@ describe("FeatherAutocomplete", () => {
       });
 
       await input.trigger("keydown", { code: Code.DOWN });
+      await input.trigger("keydown", { code: Code.DOWN });
 
       const index = wrapper.vm.active.row;
       await input.trigger("blur");
@@ -960,6 +961,7 @@ describe("FeatherAutocomplete", () => {
         results,
       });
 
+      await input.trigger("keydown", { code: Code.DOWN });
       await input.trigger("keydown", { code: Code.ENTER });
 
       expect(wrapper.element).toMatchSnapshot();

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -427,7 +427,11 @@ export default defineComponent({
       immediate: true,
     },
     results(v) {
-      if (v && v.length > 0) {
+      // if (v && v.length > 0) {
+      if (!this.singleSelect && v && v.length > 0) {
+        this.selectFirst();
+      } else if (this.singleSelect && this.firstPass) {
+        this.firstPass = false;
         this.selectFirst();
       }
       this.forceCloseResults = false; // should no longer force close
@@ -727,6 +731,7 @@ export default defineComponent({
     const hasFocus = ref(false);
     const selectionLimitReached = ref(false);
     const forceCloseResults = ref(false);
+    const firstPass = ref(true);
     const query = ref("");
     const internalResults = ref([] as IAutocompleteItemType[]);
     const input = ref();
@@ -773,6 +778,7 @@ export default defineComponent({
       internalResults,
       selectionLimitReached,
       forceCloseResults,
+      firstPass,
       hasFocus,
       strategy,
       emitSearch,

--- a/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.ts.snap
+++ b/packages/@featherds/autocomplete/src/components/__snapshots__/FeatherAutocomplete.spec.ts.snap
@@ -5737,7 +5737,7 @@ exports[`FeatherAutocomplete > single:specific > should show add new element whe
           
           
           <textarea
-            aria-activedescendant=""
+            aria-activedescendant="result-item"
             aria-autocomplete="list"
             aria-busy="false"
             aria-controls="feather-autocomplete-input-results"
@@ -5798,7 +5798,8 @@ exports[`FeatherAutocomplete > single:specific > should show add new element whe
         
         <li
           aria-selected="false"
-          class="feather-list-item hover focus result-item hover"
+          class="feather-list-item hover focus highlighted result-item hover"
+          id="result-item"
           role="option"
           style="overflow: hidden; position: relative;"
           tabindex="-1"


### PR DESCRIPTION
Address "Cannot clear single Autocomplete selection" issue.  For single select option, a default (first element) active row is set on the initial load of the control only.  If no record is initially selected, subsequent loads of the options will NOT have a default active row.