### PR TITLE
fix: handle menus inside absolute positioned containers

### DIFF
--- a/packages/@featherds/autocomplete/demos/AbsolutePositioned.vue
+++ b/packages/@featherds/autocomplete/demos/AbsolutePositioned.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="autocomplete-demo">
+    <FeatherExpansionPanel
+      no-expand
+      title="Draggable Absolute Positioning Example"
+      class="feather-panel"
+      draggable="true"
+      @mousedown.prevent="beginDrag"
+      @mousemove="continueDrag"
+      @mouseup="endDrag"
+      @mouseleave="endDrag"
+      :style="{
+        transform: `translate(${detailPos.x}px, ${detailPos.y}px)`,
+      }"
+    >
+      <template #default>
+        <div class="panel-content">
+          <p :style="{ fontStyle: 'italic' }">
+            Drag expansion panel and change selections below.
+          </p>
+          <FeatherAutocomplete
+            class="normal-select"
+            data-ref-id="test2"
+            label="WITHOUT absolute-positioned attribute"
+            v-model="assignee"
+            :loading="loading"
+            :results="results"
+            type="multi"
+            @search="search"
+            background
+          ></FeatherAutocomplete>
+          <FeatherAutocomplete
+            class="normal-select"
+            data-ref-id="test3"
+            label="WITH absolute-positioned attribute"
+            v-model="assignee2"
+            :loading="loading"
+            :results="results"
+            type="multi"
+            @search="search"
+            background
+            absolute-positioned
+          ></FeatherAutocomplete>
+        </div>
+      </template>
+    </FeatherExpansionPanel>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import { FeatherExpansionPanel } from "@featherds/expansion";
+import { FeatherAutocomplete } from "../src";
+import { IAutocompleteItemType } from "@featherds/autocomplete";
+import { useDraggable } from "@featherds/composables/events/Drag";
+
+import {
+  _setTimeout,
+  TimeoutResult,
+  _clearTimeout,
+} from "@featherds/utils/setTimeout";
+
+const {
+  position: detailPos,
+  beginDrag,
+  continueDrag,
+  endDrag,
+} = useDraggable();
+
+let timeout = ref(undefined) as unknown as TimeoutResult;
+
+const names = ["Brian", "Charlie", "Jeff", "Scott"];
+
+const assignee = ref(undefined) as unknown as IAutocompleteItemType;
+const assignee2 = ref(undefined) as unknown as IAutocompleteItemType;
+const loading = ref(false);
+const results = ref([] as IAutocompleteItemType[]);
+
+const search = async (qry: string) => {
+  loading.value = true;
+  _clearTimeout(timeout);
+
+  timeout = _setTimeout(() => {
+    results.value = names
+      .filter((name) => name.toLowerCase().indexOf(qry.toLowerCase()) > -1)
+      .map((name) => ({ _text: name }));
+    loading.value = false;
+  }, 500);
+};
+</script>
+
+<style lang="scss" scoped>
+.autocomplete-demo {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  .feather-panel {
+    cursor: move;
+    position: absolute;
+    width: 44em;
+    top: 8rem;
+    left: 12rem;
+    .panel-content {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+  }
+}
+</style>

--- a/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
+++ b/packages/@featherds/autocomplete/src/components/FeatherAutocomplete.vue
@@ -3,6 +3,7 @@
     <FeatherMenu
       fill
       no-expand
+      :absolute-positioned="absolutePositioned"
       :open="showMenu"
       @outside-click="handleOutsideClick"
       @trigger-click="handleTriggerClick"
@@ -698,6 +699,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
+    const absolutePositioned = ref(props.absolutePositioned);
     const labels = useLabelProperty<typeof LABELS>(
       toRef(props, "labels"),
       LABELS
@@ -775,6 +777,7 @@ export default defineComponent({
       ...labels,
       ...useInputInheritAttrs(context.attrs as Record<string, unknown>),
       query,
+      absolutePositioned,
       internalResults,
       selectionLimitReached,
       forceCloseResults,

--- a/packages/@featherds/autocomplete/src/components/types.ts
+++ b/packages/@featherds/autocomplete/src/components/types.ts
@@ -129,6 +129,10 @@ export const props = {
     type: Object,
     required: false,
   },
+  absolutePositioned: {
+    type: Boolean,
+    default: false,
+  },
   ...HighlightProps,
   ...InputSubTextProps,
   ...InputWrapperProps,

--- a/packages/@featherds/date-input/demos/AbsolutePositioned.vue
+++ b/packages/@featherds/date-input/demos/AbsolutePositioned.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="date-input-demo">
+    <FeatherExpansionPanel
+      no-expand
+      title="Draggable Absolute Positioning Example"
+      class="feather-panel"
+      draggable="true"
+      @mousedown.prevent="beginDrag"
+      @mousemove="continueDrag"
+      @mouseup="endDrag"
+      @mouseleave="endDrag"
+      :style="{
+        transform: `translate(${detailPos.x}px, ${detailPos.y}px)`,
+      }"
+    >
+      <template #default>
+        <div class="panel-content">
+          <p :style="{ fontStyle: 'italic' }">
+            Drag expansion panel and change selections below.
+          </p>
+          <FeatherDateInput
+            v-model="from"
+            class="my-date-input"
+            label="WITHOUT absolute-positioned attribute"
+            hint="The date input menu IS NOT absolute-positioned"
+          />
+          <FeatherDateInput
+            v-model="to"
+            class="my-date-input"
+            label="WITH absolute-positioned attribute"
+            hint="The date input menu IS absolute-positioned"
+            absolute-positioned
+          />
+        </div>
+      </template>
+    </FeatherExpansionPanel>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FeatherExpansionPanel } from "@featherds/expansion";
+import { FeatherDateInput } from "../src";
+import { useDraggable } from "@featherds/composables/events/Drag";
+import { ref } from "vue";
+
+const {
+  position: detailPos,
+  beginDrag,
+  continueDrag,
+  endDrag,
+} = useDraggable();
+
+const from = ref(undefined) as unknown as Date;
+const to = ref(undefined) as unknown as Date;
+</script>
+
+<style lang="scss" scoped>
+.date-input-demo {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  .feather-panel {
+    cursor: move;
+    position: absolute;
+    width: 44em;
+    top: 8rem;
+    left: 12rem;
+    .panel-content {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      .my-date-input {
+        width: 26em;
+      }
+    }
+  }
+}
+</style>

--- a/packages/@featherds/date-input/src/components/Calendar/Calendar.vue
+++ b/packages/@featherds/date-input/src/components/Calendar/Calendar.vue
@@ -28,6 +28,7 @@
         ref="select-month"
         data-ref-id="feather-calendar-select-month"
         class="inline-select"
+        :absolute-positioned="absolutePositioned"
       />
       <FeatherSelect
         :model-value="currentYear"
@@ -38,6 +39,7 @@
         ref="select-year"
         data-ref-id="feather-calendar-select-year"
         class="inline-select year"
+        :absolute-positioned="absolutePositioned"
       />
 
       <FeatherButton
@@ -131,6 +133,10 @@ export default defineComponent({
     labels: {
       type: Object as PropType<Partial<typeof LABELS>>,
       required: true,
+    },
+    absolutePositioned: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/packages/@featherds/date-input/src/components/FeatherDateInput.vue
+++ b/packages/@featherds/date-input/src/components/FeatherDateInput.vue
@@ -9,6 +9,7 @@
     <FeatherMenu
       right
       :open="showMenu"
+      :absolute-positioned="absolutePositioned"
       @outside-click="handleOutsideClick"
       @trigger-click="handleTriggerClick"
       class="feather-date-input-menu-container"
@@ -100,6 +101,7 @@
         :labels="labels"
         :monday-first="mondayFirst"
         :aria-label="menuLabel"
+        :absolute-positioned="absolutePositioned"
       />
     </FeatherMenu>
     <InputSubText :id="descriptionId" :error-text="error"> </InputSubText>
@@ -194,6 +196,10 @@ export const props = {
     type: Object as PropType<Date>,
     required: false,
     default: () => new Date(),
+  },
+  absolutePositioned: {
+    type: Boolean,
+    default: false,
   },
 } as const;
 export const emits = {

--- a/packages/@featherds/date-input/src/components/__snapshots__/FeatherDateInput.spec.ts.snap
+++ b/packages/@featherds/date-input/src/components/__snapshots__/FeatherDateInput.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`FeatherDateInput.vue > should render disabled 1`] = `
   class="feather-date-input-container"
 >
   <div
+    absolute-positioned="false"
     class="feather-date-input-menu-container"
     data-ref-id="feather-date-input-menu-container"
     open="false"

--- a/packages/@featherds/dropdown/demos/AbsolutePositioned.vue
+++ b/packages/@featherds/dropdown/demos/AbsolutePositioned.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="select-demo">
+    <FeatherExpansionPanel
+      no-expand
+      title="Draggable Absolute Positioning Example"
+      class="feather-panel"
+      draggable="true"
+      @mousedown.prevent="beginDrag"
+      @mousemove="continueDrag"
+      @mouseup="endDrag"
+      @mouseleave="endDrag"
+      :style="{
+        transform: `translate(${detailPos.x}px, ${detailPos.y}px)`,
+      }"
+    >
+      <template #default>
+        <div class="panel-content">
+          <p :style="{ fontStyle: 'italic' }">
+            Drag expansion panel and change selections below.
+          </p>
+          <FeatherDropdown
+            :standard="true"
+            :value="nodeOption"
+            class="my-dropdown"
+            label="WITHOUT absolute-positioned attribute"
+            hint="The dropdown menu IS NOT absolute-positioned"
+          >
+            <template #trigger="{ attrs, on }">
+              <FeatherButton
+                link
+                href="#"
+                v-bind="attrs"
+                v-on="on"
+                icon="Without Absolute Positioning"
+              >
+                <FeatherIcon :icon="NodesIcon" />
+              </FeatherButton>
+            </template>
+            <FeatherDropdownItem>HTTP</FeatherDropdownItem>
+            <FeatherDropdownItem>HTTPS</FeatherDropdownItem>
+            <FeatherDropdownItem>SMTP</FeatherDropdownItem>
+            <FeatherDropdownItem>Other</FeatherDropdownItem>
+          </FeatherDropdown>
+          <FeatherDropdown
+            :standard="true"
+            :value="powerOption"
+            class="my-dropdown"
+            label="WITH absolute-positioned attribute"
+            hint="The dropdown menu IS absolute-positioned"
+            absolute-positioned
+          >
+            <template #trigger="{ attrs, on }">
+              <FeatherButton
+                link
+                href="#"
+                v-bind="attrs"
+                v-on="on"
+                icon="With Absolute Positioning (standard)"
+              >
+                <FeatherIcon :icon="PowerIcon" />
+              </FeatherButton>
+            </template>
+            <FeatherDropdownItem>Power Off</FeatherDropdownItem>
+            <FeatherDropdownItem>Power On</FeatherDropdownItem>
+            <FeatherDropdownItem>Reboot</FeatherDropdownItem>
+          </FeatherDropdown>
+          <FeatherDropdown
+            :right="true"
+            :value="powerOption"
+            class="my-dropdown"
+            absolute-positioned
+          >
+            <template #trigger="{ attrs, on }">
+              <FeatherButton
+                link
+                href="#"
+                v-bind="attrs"
+                v-on="on"
+                icon="With Absolute Positioning (right)"
+              >
+                <FeatherIcon :icon="NotificationsIcon" />
+              </FeatherButton>
+            </template>
+            <FeatherDropdownItem>Notifications Off</FeatherDropdownItem>
+            <FeatherDropdownItem>Notifications On</FeatherDropdownItem>
+            <FeatherDropdownItem>Mute 4 hours</FeatherDropdownItem>
+            <FeatherDropdownItem>Mute 8 hours</FeatherDropdownItem>
+            <FeatherDropdownItem>Mute 24 hours</FeatherDropdownItem>
+          </FeatherDropdown>
+        </div>
+      </template>
+    </FeatherExpansionPanel>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FeatherExpansionPanel } from "@featherds/expansion";
+import { FeatherButton } from "@featherds/button";
+import { FeatherIcon } from "@featherds/icon";
+import { FeatherDropdown, FeatherDropdownItem } from "../src";
+import { useDraggable } from "@featherds/composables/events/Drag";
+
+import Notifications from "@featherds/icon/action/Notifications";
+import Nodes from "@featherds/icon/network/Nodes";
+import Power from "@featherds/icon/network/Power";
+import { computed, markRaw, ref } from "vue";
+
+const {
+  position: detailPos,
+  beginDrag,
+  continueDrag,
+  endDrag,
+} = useDraggable();
+
+const NotificationsIcon = computed(() => {
+  return markRaw(Notifications);
+});
+
+const NodesIcon = computed(() => {
+  return markRaw(Nodes);
+});
+
+const PowerIcon = computed(() => {
+  return markRaw(Power);
+});
+
+const nodeOption = ref("");
+const powerOption = ref("");
+</script>
+
+<style lang="scss" scoped>
+.select-demo {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  .feather-panel {
+    cursor: move;
+    position: absolute;
+    width: 44em;
+    top: 8rem;
+    left: 12rem;
+    .panel-content {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      .my-dropdown {
+        width: fit-content;
+      }
+    }
+  }
+}
+</style>

--- a/packages/@featherds/menu/src/components/FeatherMenu.vue
+++ b/packages/@featherds/menu/src/components/FeatherMenu.vue
@@ -161,8 +161,8 @@ export default defineComponent({
           const parent = findAbsolutePositionedParent(menu.value);
           if (parent !== null) {
             const parentRect = parent.getBoundingClientRect();
-            top = containerRect.top + containerRect.height - parentRect.top;
-            left = containerRect.left - parentRect.left;
+            top = top - parentRect.top;
+            left = left - parentRect.left;
           }
         }
         positionLeft.value = `${left}px`;

--- a/packages/@featherds/popover/demos/AbsolutePositioned.vue
+++ b/packages/@featherds/popover/demos/AbsolutePositioned.vue
@@ -1,0 +1,145 @@
+<template>
+  <div class="select-demo">
+    <div class="configuration">
+      <div>
+        Placement
+        <select name="placement" id="placement" v-model="placement">
+          <option v-for="item in placements" :key="item">{{ item }}</option>
+        </select>
+      </div>
+      <div>
+        Pointer Alignment
+        <select name="alignment" id="alignment" v-model="alignment">
+          <option v-for="item in alignments" :key="item">{{ item }}</option>
+        </select>
+      </div>
+    </div>
+
+    <FeatherExpansionPanel
+      no-expand
+      title="Draggable Absolute Positioning Example"
+      class="feather-panel"
+      draggable="true"
+      @mousedown.prevent="beginDrag"
+      @mousemove="continueDrag"
+      @mouseup="endDrag"
+      @mouseleave="endDrag"
+      :style="{
+        transform: `translate(${detailPos.x}px, ${detailPos.y}px)`,
+      }"
+    >
+      <template #default>
+        <div class="panel-content">
+          <p :style="{ fontStyle: 'italic' }">
+            Drag expansion panel and change selections below.
+          </p>
+          <p>
+            <FeatherPopover
+              :pointer-alignment="alignment"
+              :placement="placement"
+            >
+              <template #default>
+                <div>
+                  <h4>Test heading</h4>
+
+                  <p>lorem ipsum or something</p>
+                  <a href="#"> random link i guess</a>
+                </div>
+              </template>
+              <template #trigger="{ attrs, on }">
+                <FeatherButton
+                  v-bind="attrs"
+                  v-on="on"
+                  class=".more-info"
+                  type="button"
+                  text
+                  >Disembodied Popover
+                </FeatherButton>
+              </template>
+            </FeatherPopover>
+          </p>
+          <p>
+            <FeatherPopover
+              :pointer-alignment="alignment"
+              :placement="placement"
+              :absolute-positioned="true"
+            >
+              <template #default>
+                <div>
+                  <h4>Test heading</h4>
+
+                  <p>lorem ipsum or something</p>
+                  <a href="#"> random link i guess</a>
+                </div>
+              </template>
+              <template #trigger="{ attrs, on }">
+                <FeatherButton
+                  v-bind="attrs"
+                  v-on="on"
+                  class=".more-info"
+                  type="button"
+                  text
+                  >Absolute Positioned
+                </FeatherButton>
+              </template>
+            </FeatherPopover>
+          </p>
+        </div>
+      </template>
+    </FeatherExpansionPanel>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FeatherPopover } from "./../src";
+import { PointerAlignment, PopoverPlacement } from "./../src";
+import { FeatherExpansionPanel } from "@featherds/expansion";
+import { FeatherButton } from "@featherds/button";
+import { useDraggable } from "@featherds/composables/events/Drag";
+import { ref } from "vue";
+
+const {
+  position: detailPos,
+  beginDrag,
+  continueDrag,
+  endDrag,
+} = useDraggable();
+
+const placement = ref(PopoverPlacement.top);
+const placements = [
+  PopoverPlacement.top,
+  PopoverPlacement.bottom,
+  PopoverPlacement.left,
+  PopoverPlacement.right,
+];
+const alignment = ref(PointerAlignment.center);
+const alignments = [
+  PointerAlignment.center,
+  PointerAlignment.left,
+  PointerAlignment.right,
+];
+</script>
+
+<style lang="scss" scoped>
+.select-demo {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  .feather-panel {
+    cursor: move;
+    position: absolute;
+    width: 32em;
+    top: 8rem;
+    left: 12rem;
+    .panel-content {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      .more-info {
+        margin-top: 1rem;
+      }
+    }
+  }
+}
+</style>

--- a/packages/@featherds/popover/src/components/FeatherPopover.vue
+++ b/packages/@featherds/popover/src/components/FeatherPopover.vue
@@ -2,6 +2,7 @@
   <slot name="trigger" :attrs="attrs" :on="listeners"> </slot>
   <Transition :css="animate">
     <div
+      v-bind:absolute-positioned="absolutePositioned ? '' : null"
       class="feather-popover-container"
       v-if="show"
       ref="popover"
@@ -44,6 +45,10 @@ export const props = {
   pointerAlignment: {
     type: String as PropType<PointerAlignment>,
     default: () => PointerAlignment.center,
+  },
+  absolutePositioned: {
+    type: Boolean,
+    default: false,
   },
 } as const;
 export default defineComponent({
@@ -151,6 +156,22 @@ export default defineComponent({
       return placementSelected.value ? "p-" + placementSelected.value : false;
     });
 
+    const findAbsolutePositionedParent = (element: HTMLElement) => {
+      let parent = element.closest("div");
+      while (parent) {
+        const style = window.getComputedStyle(parent);
+        if (style.position === "absolute") {
+          return parent;
+        }
+        if (parent.parentElement) {
+          parent = parent.parentElement.closest("div");
+        } else {
+          parent = null;
+        }
+      }
+      return null;
+    };
+
     const positionPopover = (popoverElement: HTMLElement) => {
       const triggerElement = document.querySelector(`[${idAttr}=${triggerID}]`);
 
@@ -236,6 +257,15 @@ export default defineComponent({
               //align to the right and allow space for arrow offset
               leftCal = triggerBoxCenter - popoverBox.width + arrowOffset;
               break;
+          }
+        }
+
+        if (props.absolutePositioned) {
+          const parent = findAbsolutePositionedParent(popover.value);
+          if (parent !== null) {
+            const parentRect = parent.getBoundingClientRect();
+            topCal = topCal - parentRect.top;
+            leftCal = leftCal - parentRect.left;
           }
         }
 


### PR DESCRIPTION
When adding controls to an absolute positioned draggable container, the menus associated with certain controls can become untethered to the main control:

- Autocomplete
- DateInput
- Dropdown
- Popover
- Select

Adding the new absolute-positioned attribute to these controls in those scenarios will consider this in positioning the menu.