### PR TITLE
chore(package): remove private flag from panel-bar package.json

### DIFF
--- a/packages/@featherds/panel-bar/package.json
+++ b/packages/@featherds/panel-bar/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@featherds/panel-bar",
   "version": "0.12.36",
-  "private": true,
   "author": "NantHealth",
   "scripts": {},
   "main": "dist/app.mjs",


### PR DESCRIPTION
PanelBar did not publish.  Was still marked as private.