### PR TITLE
feat(dock): respect current padding; add --feather-dock-header-offset

### DIFF
--- a/packages/@featherds/dock/demos/FullMain.vue
+++ b/packages/@featherds/dock/demos/FullMain.vue
@@ -1,0 +1,179 @@
+<template>
+  <div class="wrapper">
+    <FeatherDock
+      id="my-dock-full-main"
+      :pushedSelector="'.dock-demo-full-layout'"
+      @update:dock-expanded="requestDockExpansion"
+      @update:dock-collapsed="console.log('dock collapsed')"
+    >
+      <template #docked>
+        <FeatherIcon
+          class="dock-icon"
+          :icon="markRaw(Certificate)"
+          @click="requestDockExpansion"
+        />
+      </template>
+    </FeatherDock>
+    <div class="dock-demo-full-layout">
+      <header class="header">
+        <h1>Website Header</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </header>
+
+      <div class="content-wrapper">
+        <aside class="aside">
+          <h3>Sidebar</h3>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </p>
+          <ul>
+            <li>Navigation Item 1</li>
+            <li>Navigation Item 2</li>
+            <li>Navigation Item 3</li>
+          </ul>
+        </aside>
+
+        <main class="main">
+          <h2>Main Content Area</h2>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </p>
+          <p>
+            Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </p>
+          <p>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+            quae ab illo inventore veritatis et quasi architecto beatae vitae
+            dicta sunt explicabo.
+          </p>
+        </main>
+      </div>
+
+      <footer class="footer">
+        <p>
+          &copy; 2025 Feather Design System. Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit.
+        </p>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { markRaw } from "vue";
+import Certificate from "@featherds/icon/communication/Certificate";
+import { FeatherIcon } from "@featherds/icon";
+import { FeatherDock } from "@featherds/dock";
+
+function requestDockExpansion() {
+  console.log("dock expansion requested");
+}
+</script>
+
+<style lang="scss">
+.feather-styles:has(.dock-demo-full-layout) {
+  background-color: rgba(0, 34, 238, 0.12);
+  .feather-container {
+    max-width: 100vw;
+    margin: 0;
+  }
+}
+#my-dock-full-main {
+  // for demo purposes, this the height of the theme picker select container.
+  --feather-dock-header-offset: 44px;
+}
+@media (min-width: 90.0625rem) {
+  .feather-styles:has(.dock-demo-full-layout) {
+    .feather-container {
+      padding-right: 0;
+      padding-left: 0;
+    }
+  }
+}
+</style>
+
+<style lang="scss" scoped>
+@use "@featherds/styles/themes/variables" as vars;
+@use "@featherds/styles/themes/utils" as utils;
+@use "@featherds/styles/mixins/typography" as typo;
+
+.dock-demo-full-layout {
+  // 44px is the height of the theme changer in demos
+  min-height: calc(100vh - 44px);
+  display: flex;
+  flex-direction: column;
+  font-family: Arial, sans-serif;
+  padding-inline: 1rem;
+}
+
+.dock-icon {
+  font-size: 1.75em;
+}
+
+.header {
+  background-color: utils.alpha(vars.$categorical10, 0.4);
+  padding: 2rem;
+}
+
+.content-wrapper {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.aside {
+  background-color: utils.alpha(vars.$categorical10, 0.2);
+  padding: 2rem;
+  width: 250px;
+  flex-shrink: 0;
+}
+
+.aside h3 {
+  margin: 0 0 1rem 0;
+}
+
+.aside ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0 0;
+}
+
+.aside li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #bdc3c7;
+}
+
+.main {
+  background-color: var(vars.$surface);
+  padding: 2rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.main h2 {
+  margin: 0 0 1rem 0;
+}
+
+.main p {
+  margin: 0 0 1rem 0;
+  line-height: 1.6;
+}
+
+.footer {
+  background-color: utils.alpha(vars.$categorical10, 0.1);
+  padding: 1.5rem 2rem;
+  text-align: center;
+}
+
+.footer p {
+  margin: 0;
+}
+</style>

--- a/packages/@featherds/dock/src/components/FeatherDock.vue
+++ b/packages/@featherds/dock/src/components/FeatherDock.vue
@@ -79,6 +79,8 @@ const dockContentRef = ref<HTMLElement | undefined>(undefined);
 
 const isDockOpen = ref(props.modelValue);
 
+const pushedSelectorPadding = ref("");
+
 watch(
   () => props.modelValue,
   (newVal: boolean) => {
@@ -185,8 +187,15 @@ const updatePushedElement = () => {
         const isInFlow = position === "static" || position === "relative";
 
         const widthFromProps = dockConfig.value.isOpen
-          ? props.expandedWidth
-          : props.collapsedWidth;
+          ? `${
+              parseInt(convertToPixels(props.expandedWidth)) +
+              parseInt(convertToPixels(pushedSelectorPadding.value))
+            }px`
+          : `${
+              parseInt(convertToPixels(props.collapsedWidth)) +
+              parseInt(convertToPixels(pushedSelectorPadding.value))
+            }px`;
+
         // @ts-ignore
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const widthInPx = dockConfig.value.isOpen
@@ -201,12 +210,12 @@ const updatePushedElement = () => {
           //   position,
           //   widthFromProps
           // );
-          const marginProperty =
+          const paddingProperty =
             dockConfig.value.location === "left"
-              ? "margin-left"
-              : "margin-right";
+              ? "padding-left"
+              : "padding-right";
 
-          element.style.setProperty(marginProperty, widthFromProps);
+          element.style.setProperty(paddingProperty, widthFromProps);
         } else {
           // console.warn("Outflow element found:", selector, position, widthInPx);
           // console.warn("Outflow not supported yet");
@@ -270,6 +279,22 @@ provide(
 provide("dockConfig", readonly(dockConfig)); //readonly
 
 onMounted(() => {
+  if (props.pushedSelector) {
+    const selector = Array.isArray(props.pushedSelector)
+      ? props.pushedSelector[0]
+      : props.pushedSelector;
+
+    if (!selector) return;
+    const element = document.querySelector(selector) as HTMLElement;
+
+    if (!element) return;
+    pushedSelectorPadding.value =
+      dockConfig.value.location === "left"
+        ? window.getComputedStyle(element).paddingLeft
+        : window.getComputedStyle(element).paddingRight;
+  }
+
+  // Update the pushed element padding
   updatePushedElement();
   document.addEventListener("keydown", handleSidebarEscape);
 });
@@ -297,8 +322,8 @@ onUnmounted(() => {
             // console.log("Inflow element found:", selector, position);
             element.style.removeProperty(
               dockConfig.value.location === "left"
-                ? "margin-left"
-                : "margin-right"
+                ? "padding-left"
+                : "padding-right"
             );
           } else {
             console.warn("Outflow element found:", selector, position);
@@ -350,6 +375,7 @@ onUnmounted(() => {
   --feather-dock-content-padding-top: 3rem;
   --feather-dock-toggle-top: 0.25rem;
   --feather-dock-timing: 0.3s;
+  --feather-dock-header-offset: 0px;
 
   @media (prefers-reduced-motion: reduce) {
     --feather-dock-timing: 0.1s; /* nearly instant */
@@ -378,7 +404,7 @@ onUnmounted(() => {
   );
 
   position: fixed;
-  inset: 0 0 0 0;
+  inset: var(--feather-dock-header-offset) 0 0 0;
   border-radius: 0;
 
   width: var(--feather-dock-width);
@@ -388,7 +414,7 @@ onUnmounted(() => {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: var(--feather-dock-color) transparent;
-  z-index: var(vars.$zindex-modal);
+  z-index: var(vars.$zindex-fixed);
 
   @include elev.elevation(16);
   transition: all var(--feather-dock-timing, 0.3s);
@@ -414,11 +440,17 @@ onUnmounted(() => {
       left: calc(var(--feather-dock-width) / 2 - 1.5rem);
       margin: auto 0.5rem;
     }
+    > .feather-dock-toggle {
+      top: var(--feather-dock-toggle-top);
+    }
   }
   & > .feather-dock-toggle {
     @include utils.state-on-neutral();
     position: fixed;
-    top: var(--feather-dock-toggle-top, 1rem);
+
+    top: calc(
+      var(--feather-dock-toggle-top) + var(--feather-dock-header-offset)
+    );
     left: calc(var(--feather-dock-width) - 1rem);
     background-color: var(--feather-dock-background-color);
     color: var(--feather-dock-color);


### PR DESCRIPTION
- Replace dock space allowance to use padding instead of margin.
- Respect current padding of element designated as "pushedSelector" on collapse and expand.
- Provide css variable --feather-dock-header-offset to allow consumers to push the Dock/Sidenav/Sidebar below any fixed header.